### PR TITLE
요리 완료, 멤버, 알림, 냉장고, 리뷰 엔티티 매핑 #2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'io.hypersistence:hypersistence-utils-hibernate-62:3.6.1'
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -1,0 +1,74 @@
+
+# Create fridge Table
+create table fridge
+(
+    fridge_id   bigint unique not null auto_increment,
+    created_at  datetime(6) not null,
+    modified_at datetime(6),
+
+    primary key (fridge_id)
+);
+
+# Create member Table
+create table member
+(
+    member_id   bigint unique      not null auto_increment,
+    fridge_id   bigint             not null,
+    name        varchar(15)        not null,
+    nickname    varchar(15)        not null,
+    email       varchar(50) unique not null,
+    phone       varchar(11),
+    password    varchar(100)       not null,
+    role        enum ('USER','ADMIN') not null,
+    provider    enum('EMAIL','GOOGLE') not null,
+    provider_id varchar(100),
+    jwt_token   varchar(255),
+    created_at  datetime(6) not null,
+    modified_at datetime(6),
+
+    primary key (member_id),
+    foreign key (fridge_id) references fridge (fridge_id)
+);
+
+# Create notification Table
+create table notification
+(
+    notification_id   bigint unique not null auto_increment,
+    member_id         bigint        not null,
+    notification_type enum ('INGREDIENT_EXPIRED','RECIPE_REVIEWED','RECIPE_RECOMMENDED'),
+    notification_text json          not null,
+    created_at        datetime(6) not null,
+    checked_at        datetime(6) null,
+
+    primary key (notification_id),
+    foreign key (member_id) references member (member_id)
+);
+
+# 레시피 후기 테이블 생성
+create table review
+(
+    review_id   bigint unique not null auto_increment,
+    member_id   bigint        not null,
+    #           recipe_id bigint not null,
+    cook_id     bigint        not null,
+    title       varchar(50)   not null,
+    image_url   varchar(100),
+    contents    varchar(1000) not null,
+    created_at  datetime(6) not null,
+    modified_at datetime(6),
+
+    primary key (review_id),
+    foreign key (member_id) references member (member_id) # foreign key (recipe_id) references recipe (recipe_id)
+);
+
+# Create cook Table
+create table cook
+(
+    cook_id    bigint unique not null auto_increment,
+    member_id  bigint        not null,
+    #          recipe_id bigint not null,
+    created_at datetime(6) not null,
+
+    primary key (cook_id),
+    foreign key (member_id) references member (member_id) # foreign key (recipe_id) references recipe (recipe_id)
+)

--- a/src/main/java/team/rescue/fridge/config/JpaConfig.java
+++ b/src/main/java/team/rescue/fridge/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package team.rescue.fridge.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}

--- a/src/main/java/team/rescue/fridge/fridge/Fridge.java
+++ b/src/main/java/team/rescue/fridge/fridge/Fridge.java
@@ -1,0 +1,38 @@
+package team.rescue.fridge.fridge;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "fridge")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Fridge {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "fridge_id")
+	private Long id;
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "modified_at")
+	private LocalDateTime modifiedAt;
+
+}

--- a/src/main/java/team/rescue/fridge/member/entity/Member.java
+++ b/src/main/java/team/rescue/fridge/member/entity/Member.java
@@ -1,0 +1,135 @@
+package team.rescue.fridge.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import team.rescue.fridge.fridge.Fridge;
+import team.rescue.fridge.notification.Notification;
+import team.rescue.fridge.review.entity.Cook;
+import team.rescue.fridge.review.entity.Review;
+
+@Entity
+@Table(name = "member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Member {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "member_id")
+	private Long id;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "fridge_id")
+	private Fridge fridge;
+
+	@Column(name = "name", nullable = false, length = 15)
+	private String name;
+
+	@Column(name = "nickname", nullable = false, length = 15)
+	private String nickname;
+
+	@Column(name = "email", unique = true, nullable = false, length = 50)
+	private String email;
+
+	@Column(name = "phone", unique = true, length = 11)
+	private String phone;
+
+	@Column(name = "password", nullable = false, length = 100)
+	private String password;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "role", nullable = false, length = 10)
+	private RoleType role;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "provider", nullable = false, length = 10)
+	private ProviderType provider;
+
+	@Column(name = "provider_id", length = 100)
+	private String providerId;
+
+	@Column(name = "jwt_token")
+	private String token;
+
+	// 알림 조회
+	@OneToMany(mappedBy = "member")
+	private final List<Notification> notificationList = new ArrayList<>();
+
+	// 요리 완료 조회
+	@OneToMany(mappedBy = "member")
+	private final List<Cook> cookList = new ArrayList<>();
+
+	// 레시피 후기 조회
+	@OneToMany(mappedBy = "member")
+	private final List<Review> reviewList = new ArrayList<>();
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "modified_at")
+	private LocalDateTime modifiedAt;
+
+
+	@Builder
+	private Member(Long id, Fridge fridge, String name, String nickname, String email, String phone,
+			String password, ProviderType provider, String providerId, String token, LocalDateTime createdAt,
+			LocalDateTime modifiedAt) {
+		this.id = id;
+		this.fridge = fridge;
+		this.name = name;
+		this.nickname = nickname;
+		this.email = email;
+		this.phone = phone;
+		this.password = password;
+		this.provider = provider;
+		this.providerId = providerId;
+		this.token = token;
+		this.createdAt = createdAt;
+		this.modifiedAt = modifiedAt;
+	}
+
+	public Member createmMember(
+			Fridge fridge,
+			String name,
+			String nickname,
+			String email,
+			String phone,
+			String password,
+			ProviderType provider
+	) {
+
+		return Member.builder()
+				.fridge(fridge)
+				.name(name)
+				.nickname(nickname)
+				.email(email)
+				.phone(phone)
+				.password(password)
+				.provider(provider)
+				.build();
+	}
+}

--- a/src/main/java/team/rescue/fridge/member/entity/ProviderType.java
+++ b/src/main/java/team/rescue/fridge/member/entity/ProviderType.java
@@ -1,0 +1,6 @@
+package team.rescue.fridge.member.entity;
+
+public enum ProviderType {
+
+	EMAIL, GOOGLE
+}

--- a/src/main/java/team/rescue/fridge/member/entity/RoleType.java
+++ b/src/main/java/team/rescue/fridge/member/entity/RoleType.java
@@ -1,0 +1,5 @@
+package team.rescue.fridge.member.entity;
+
+public enum RoleType {
+	USER, ADMIN
+}

--- a/src/main/java/team/rescue/fridge/notification/Notification.java
+++ b/src/main/java/team/rescue/fridge/notification/Notification.java
@@ -1,0 +1,55 @@
+package team.rescue.fridge.notification;
+
+import io.hypersistence.utils.hibernate.type.json.JsonType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Type;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import team.rescue.fridge.member.entity.Member;
+
+@Entity
+@Table(name = "notification")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Notification {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "notification_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "notification_type")
+	private NotificationType notificationType;
+
+	@Type(JsonType.class)
+	@Column(name = "notification_text", columnDefinition = "json", nullable = false)
+	private NotificationText notificationText;  // TODO: 조금 더 좋은 이름 필요
+
+	@Column(name = "checked_at")
+	private LocalDateTime checkedAt;
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+}

--- a/src/main/java/team/rescue/fridge/notification/NotificationText.java
+++ b/src/main/java/team/rescue/fridge/notification/NotificationText.java
@@ -1,0 +1,25 @@
+package team.rescue.fridge.notification;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class NotificationText {
+	private Long originId;            // 알림 발생 ID(유통기한 지난 재료 = null, 레시피 후기 남긴 유저 ID, 오늘의 추천 레시피 = null)
+	private Long originUserId;        // 알림 발생 주체 ID (유통기한 지난 재료 ID, 후기 달린 레시피 ID, 추천 레시피 ID)
+	private String contents;          // 유통기한 지난 재료 이름, 후기 제목, 추천 레시피 제목
+
+	@Builder
+	public NotificationText(
+			Long originId,
+			Long originUserId,
+			String contents
+	) {
+
+		this.originId = originId;
+		this.originUserId = originUserId;
+		this.contents = contents;
+	}
+}

--- a/src/main/java/team/rescue/fridge/notification/NotificationType.java
+++ b/src/main/java/team/rescue/fridge/notification/NotificationType.java
@@ -1,0 +1,6 @@
+package team.rescue.fridge.notification;
+
+public enum NotificationType {
+
+	INGREDIENT_EXPIRED, RECIPE_REVIEWED, RECIPE_RECOMMENDED
+}

--- a/src/main/java/team/rescue/fridge/review/entity/Cook.java
+++ b/src/main/java/team/rescue/fridge/review/entity/Cook.java
@@ -1,0 +1,45 @@
+package team.rescue.fridge.review.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import team.rescue.fridge.member.entity.Member;
+
+@Entity
+@Table(name = "cook")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Cook {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "cook_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	// TODO: 레시피 테이블 매핑
+//	@ManyToOne(fetch = FetchType.LAZY)
+//	@JoinColumn(name = "recipe_id")
+//	private Recipe recipe;
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+}

--- a/src/main/java/team/rescue/fridge/review/entity/Review.java
+++ b/src/main/java/team/rescue/fridge/review/entity/Review.java
@@ -1,0 +1,63 @@
+package team.rescue.fridge.review.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import team.rescue.fridge.member.entity.Member;
+
+@Entity
+@Table(name = "review")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Review {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "review_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	// TODO: 레시피 테이블 매핑
+//	@ManyToOne(fetch = FetchType.LAZY)
+//	@JoinColumn(name = "recipe_id")
+//	private Recipe recipe;
+
+	@Column(name = "title", nullable = false, length = 50)
+	private String title;
+
+	@Column(name = "image_url")
+	private String image_url;
+
+	@Column(name = "contents", nullable = false, length = 1000)
+	private String contents;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "cook_id")
+	private Cook cook;
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "modified_at")
+	private LocalDateTime modifiedAt;
+}


### PR DESCRIPTION
### 작업 내용 요약 
테이블 생성 및 엔티티 매핑

### 변경점
**AS-IS**


**TO-BE**

- fridge
- member
- review
- notification
- cook

JSON 타입 컬럼 부분 주석으로 각 알림 케이스마다 NotificationText에 어떤 값이 들어가는지 적어두었습니다.

```java
@Getter
@RequiredArgsConstructor
public class NotificationText {
	private Long originId;            // 알림 발생 ID(유통기한 지난 재료 = null, 레시피 후기 남긴 유저 ID, 오늘의 추천 레시피 = null)
	private Long originUserId;        // 알림 발생 주체 ID (유통기한 지난 재료 ID, 후기 달린 레시피 ID, 추천 레시피 ID)
	private String contents;          // 유통기한 지난 재료 이름, 후기 제목, 추천 레시피 제목

	@Builder
	public NotificationText(
		Long originId,
		Long originUserId,
		String contents
	) {

		this.originId = originId;
		this.originUserId = originUserId;
		this.contents = contents;
	}
}
```

### 비고
레시피 테이블 제외하고 우선 생성했습니다. 
테이블 매핑 작업이 있는 경우에는 등록 기능까지 완료한 이후 PR이 아니라, 매핑 부분만 먼저 작업해서 PR 주시면 더 좋을 것 같습니다.


### 테스트
해당 없음

- [ ] 테스트 코드 작성
- [ ] API 테스트 
