### PR TITLE
Google 로그인 후 회원가입 처리 #10

### DIFF
--- a/src/main/java/team/rescue/fridge/member/MemberRepository.java
+++ b/src/main/java/team/rescue/fridge/member/MemberRepository.java
@@ -1,11 +1,15 @@
 package team.rescue.fridge.member;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import team.rescue.fridge.member.entity.Member;
+import team.rescue.fridge.member.entity.ProviderType;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	boolean existsByEmail(String email);
+
+	Optional<Member> findByProviderAndProviderId(ProviderType provider, String providerId);
 }

--- a/src/main/java/team/rescue/fridge/oauth/PrincipalDetails.java
+++ b/src/main/java/team/rescue/fridge/oauth/PrincipalDetails.java
@@ -1,0 +1,35 @@
+package team.rescue.fridge.oauth;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import team.rescue.fridge.member.entity.Member;
+
+@Getter
+@AllArgsConstructor
+public class PrincipalDetails implements OAuth2User {
+
+	private Member member;
+	private Map<String, Object> attributes;
+
+	@Override
+	public Map<String, Object> getAttributes() {
+		return this.attributes;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		Collection<GrantedAuthority> collect = new ArrayList<>();
+		collect.add((GrantedAuthority) () -> member.getRole().toString());
+
+		return collect;
+	}
+	@Override
+	public String getName() {
+		return attributes.get("sub").toString();
+	}
+}

--- a/src/main/java/team/rescue/fridge/oauth/controller/OAuth2Controller.java
+++ b/src/main/java/team/rescue/fridge/oauth/controller/OAuth2Controller.java
@@ -1,0 +1,19 @@
+package team.rescue.fridge.oauth.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2Controller {
+
+	@GetMapping("/auth/login/google")
+	public void redirectGoogleLogin(HttpServletResponse response) throws IOException {
+		response.sendRedirect("/oauth2/authorization/google");
+	}
+}

--- a/src/main/java/team/rescue/fridge/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/team/rescue/fridge/oauth/handler/OAuth2SuccessHandler.java
@@ -4,17 +4,25 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import team.rescue.fridge.oauth.PrincipalDetails;
 
 @Component
+@Slf4j
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
 			Authentication authentication) throws IOException, ServletException {
-			// TODO: OAuth2 인증 성공 후 실행할 로직 작성
-			// 현재 로그인 이후 아무 화면도 안나오는데 그것도 여기서 해결
+		// TODO: OAuth2 인증 성공 후 실행할 로직 작성
+
+		// SecurityContext에 저장된 Authentication 객체
+		PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+		log.info(principalDetails.getAttributes().toString());
+
+		// 여기서 jwt 토큰을 가지고 로그인 로직 구현
 	}
 }

--- a/src/main/java/team/rescue/fridge/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/team/rescue/fridge/oauth/service/CustomOAuth2UserService.java
@@ -48,6 +48,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 				= memberRepository.findByProviderAndProviderId(provider, providerId);
 
 		if (findMember.isEmpty()) {
+			if (memberRepository.existsByEmail(email)) {
+				log.error("이미 존재하는 email. 다른 email을 사용하도록 하기 위한 방법 필요.");
+				throw new RuntimeException();
+			}
+
 			Member savedMember = memberRepository.save(Member.builder()
 					.name(name)
 					.email(email)

--- a/src/main/java/team/rescue/fridge/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/team/rescue/fridge/oauth/service/CustomOAuth2UserService.java
@@ -21,6 +21,11 @@ import team.rescue.fridge.oauth.PrincipalDetails;
 @Slf4j
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
+	private static final String PROVIDER_ID = "sub";
+	private static final String NICKNAME = "given_name";
+	private static final String NAME = "name";
+	private static final String EMAIL = "email";
+
 	private final PasswordEncoder passwordEncoder;
 	private final MemberRepository memberRepository;
 
@@ -31,10 +36,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 		ProviderType provider = ProviderType.valueOf(
 				userRequest.getClientRegistration().getRegistrationId().toUpperCase()); // google
-		String providerId = oAuth2User.getAttribute("sub");
-		String nickname = oAuth2User.getAttribute("given_name");
-		String name = oAuth2User.getAttribute("name");
-		String email = oAuth2User.getAttribute("email");
+		String providerId = oAuth2User.getAttribute(PROVIDER_ID);
+		String nickname = oAuth2User.getAttribute(NICKNAME);
+		String name = oAuth2User.getAttribute(NAME);
+		String email = oAuth2User.getAttribute(EMAIL);
 
 		String createdPassword = UUID.randomUUID().toString().replace("-", "").substring(0, 20);
 		String encryptedPassword = passwordEncoder.encode(createdPassword);

--- a/src/main/java/team/rescue/fridge/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/team/rescue/fridge/oauth/service/CustomOAuth2UserService.java
@@ -1,23 +1,61 @@
 package team.rescue.fridge.oauth.service;
 
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import team.rescue.fridge.member.MemberRepository;
+import team.rescue.fridge.member.entity.Member;
+import team.rescue.fridge.member.entity.ProviderType;
+import team.rescue.fridge.member.entity.RoleType;
+import team.rescue.fridge.oauth.PrincipalDetails;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
+	private final PasswordEncoder passwordEncoder;
+	private final MemberRepository memberRepository;
+
 	@Override
 	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 		OAuth2User oAuth2User = super.loadUser(userRequest);
 		log.info(oAuth2User.getAttributes().toString());
 
-		return oAuth2User;
+		ProviderType provider = ProviderType.valueOf(
+				userRequest.getClientRegistration().getRegistrationId().toUpperCase()); // google
+		String providerId = oAuth2User.getAttribute("sub");
+		String nickname = oAuth2User.getAttribute("given_name");
+		String name = oAuth2User.getAttribute("name");
+		String email = oAuth2User.getAttribute("email");
+
+		String createdPassword = UUID.randomUUID().toString().replace("-", "").substring(0, 20);
+		String encryptedPassword = passwordEncoder.encode(createdPassword);
+
+		Optional<Member> findMember
+				= memberRepository.findByProviderAndProviderId(provider, providerId);
+
+		if (findMember.isEmpty()) {
+			Member savedMember = memberRepository.save(Member.builder()
+					.name(name)
+					.email(email)
+					.nickname(nickname)
+					.password(encryptedPassword)
+					.role(RoleType.USER)
+					.provider(provider)
+					.providerId(providerId)
+					.build());
+
+			return new PrincipalDetails(savedMember, oAuth2User.getAttributes());
+		} else {
+			return new PrincipalDetails(findMember.get(), oAuth2User.getAttributes());
+		}
 	}
 }


### PR DESCRIPTION
### 작업 내용 요약 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 변경점
<!---- 실제로 변경된 부분을 작성해주세요. -->
**AS-IS**
- 기존에는 http://localhost:8081/oauth2/authorization/google 로 직접 접속하도록 구현했었음

**TO-BE**
- OAuth2Controller를 생성해서 "/auth/login/google" 엔드포인트로 접근 시 구글 로그인 페이지로 이동하도록 수정
- CustomOAuth2UserService에서 구글에서 보내준 정보를 바탕으로 처음 로그인하는 사용자라면 회원가입이 되도록 구현
- provider와 providerId 필드를 이용해서 이전에 접속했던 사용자인지를 판별하도록 함
- nickname을 null값으로 넘겨주려고 했었는데 nickname 필드가 not null 처리 되어 있어서 일단 구글에서 보내주는 정보 중 given_name 필드를 nickname 값으로 사용하도록 했습니다.
- 비밀번호는 `UUID.randomUUID()`를 사용해서 임의로 생성하여 암호화해서 저장하도록 했습니다. 

- OAuth2User를 구현한 PrincipalDetails 클래스를 생성.
- TokenProvider 구현 완료되면 successHandler에서 accessToken, refreshToken 만들어서 보내주면 될 것 같습니다.

### 비고
<!---- 리뷰어에게 하고 싶은 말이나, 참고해야할 부분이 있다면 알려주세요. -->
- PrincipalDetails 클래스에 UserDetails도 함께 구현하도록 해도 될 것 같습니다.
- AuthController에 구글 로그인으로 이동시키는 메서드 생성하려 했는데 smtp 패키지 내부에 들어있어서 일단 OAuth2Controller 따로 생성했습니다.
- 추가적인 의견 있으시면 말씀해주세요!

### 테스트
<!---- 어떤 테스트를 진행했는지 적어주세요.-->

- [ ] 테스트 코드 작성
- [ ] API 테스트 
