### PR TITLE
Spring Security 초기 세팅 및 jwt 기반 인증 인가 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'com.auth0:java-jwt:4.4.0'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'

--- a/src/main/java/team/rescue/fridge/config/RedisConfig.java
+++ b/src/main/java/team/rescue/fridge/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package team.rescue.fridge.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+  @Value("${spring.data.redis.port}")
+  private int port;
+
+  @Value("${spring.data.redis.host}")
+  private String host;
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory(host, port);
+  }
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate() {
+    // redisTemplate를 받아와서 set, get, delete를 사용
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    // setKeySerializer, setValueSerializer 설정
+    // redis-cli을 통해 직접 데이터를 조회 시 알아볼 수 없는 형태로 출력되는 것을 방지
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new StringRedisSerializer());
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+    return redisTemplate;
+  }
+}

--- a/src/main/java/team/rescue/fridge/config/SecurityConfig.java
+++ b/src/main/java/team/rescue/fridge/config/SecurityConfig.java
@@ -1,17 +1,40 @@
 package team.rescue.fridge.config;
 
+import static org.springframework.security.config.Customizer.withDefaults;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.DispatcherType;
+import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import team.rescue.fridge.handler.AuthenticationExceptionHandler;
+import team.rescue.fridge.handler.AuthorizationExceptionHandler;
 import team.rescue.fridge.oauth.handler.OAuth2FailureHandler;
 import team.rescue.fridge.oauth.handler.OAuth2SuccessHandler;
 import team.rescue.fridge.oauth.service.CustomOAuth2UserService;
+import team.rescue.fridge.security.JwtAuthenticationFilter;
+import team.rescue.fridge.security.JwtAuthorizationFilter;
+import team.rescue.fridge.security.MemberDetailService;
+import team.rescue.fridge.security.RedisUtil;
 
+@Slf4j
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -20,6 +43,10 @@ public class SecurityConfig {
 	private final CustomOAuth2UserService oAuth2UserService;
 	private final OAuth2SuccessHandler oAuth2SuccessHandler;
 	private final OAuth2FailureHandler oAuth2FailureHandler;
+	private final RedisUtil redisUtil;
+	private final PasswordEncoder passwordEncoder;
+	private final MemberDetailService memberDetailService;
+	private final ObjectMapper objectMapper;
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -34,7 +61,66 @@ public class SecurityConfig {
 						oauth2Login.userInfoEndpoint(userInfoEndpointConfig ->
 										userInfoEndpointConfig.userService(oAuth2UserService))
 								.successHandler(oAuth2SuccessHandler)
-								.failureHandler(oAuth2FailureHandler));
+								.failureHandler(oAuth2FailureHandler))
+				.headers((headerConfig) ->
+						headerConfig.frameOptions(FrameOptionsConfig::disable)
+				) // h2-console 화면을 사용하기 위해 iframe 비허용 처리
+				.cors(cors -> cors.configurationSource(corsConfigurationSource()))  // CORS
+				.logout(withDefaults())
+				.authorizeHttpRequests((authorizeRequests) ->
+								authorizeRequests
+										.dispatcherTypeMatchers(DispatcherType.FORWARD).permitAll()
+										.requestMatchers(PathRequest.toH2Console()).permitAll() // h2 콘솔
+										.requestMatchers("/", "/login/**").permitAll()  // 메인 화면, 로그인 화면, url path가 구체적으로 나오면 다시 수정.
+//                .requestMatchers("/post/**").hasRole(Role.USER.name)  // post관련 요청은 User role만. 나중에 Role을 추가하면 추가하기로.
+										.anyRequest().authenticated()
+				);
+		http.apply(new CustomSecurityFilterManager());
+
+		// exceptionHandling 추가
+		http
+				.exceptionHandling(exceptionHandler -> {
+					exceptionHandler.authenticationEntryPoint(
+							new AuthenticationExceptionHandler()); // 인증 실패(401)
+					exceptionHandler.accessDeniedHandler(
+							new AuthorizationExceptionHandler()); // 인가(권한) 오류(403)
+				});
+
 		return http.build();
+	}
+
+	CorsConfigurationSource corsConfigurationSource() {
+		log.debug("[+] corsConfigurationSource 등록");
+
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowedOrigins(Arrays.asList("*"));  // 나중에 프론트 출처만 허용해야함
+		configuration.setAllowedMethods(Arrays.asList("*"));
+		configuration.setAllowedHeaders(List.of("*"));
+		configuration.setAllowCredentials(true);  //클라이언트가 쿠키나 인증 관련 헤더를 사용하여 요청을 할 수 있도록 허용
+
+		// 모든 주소요청에 적용
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
+	}
+
+	@Bean
+	AuthenticationManager authenticationManager() {
+		log.debug("[+] AuthenticationManager 등록");
+		DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+		provider.setUserDetailsService(memberDetailService);
+		provider.setPasswordEncoder(passwordEncoder);
+		return new ProviderManager(provider);
+	}
+
+	public class CustomSecurityFilterManager
+			extends AbstractHttpConfigurer<CustomSecurityFilterManager, HttpSecurity> {
+		@Override
+		public void configure(HttpSecurity builder) throws Exception {
+			AuthenticationManager authenticationManager = builder.getSharedObject(AuthenticationManager.class);
+			builder.addFilter(new JwtAuthenticationFilter(authenticationManager, objectMapper, redisUtil));
+			builder.addFilter(new JwtAuthorizationFilter(authenticationManager));
+			super.configure(builder);
+		}
 	}
 }

--- a/src/main/java/team/rescue/fridge/config/SecurityConfig.java
+++ b/src/main/java/team/rescue/fridge/config/SecurityConfig.java
@@ -93,8 +93,8 @@ public class SecurityConfig {
 		log.debug("[+] corsConfigurationSource 등록");
 
 		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.setAllowedOrigins(Arrays.asList("*"));  // 나중에 프론트 출처만 허용해야함
-		configuration.setAllowedMethods(Arrays.asList("*"));
+		configuration.setAllowedOrigins(List.of("*"));  // 나중에 프론트 출처만 허용해야함
+		configuration.setAllowedMethods(List.of("*"));
 		configuration.setAllowedHeaders(List.of("*"));
 		configuration.setAllowCredentials(true);  //클라이언트가 쿠키나 인증 관련 헤더를 사용하여 요청을 할 수 있도록 허용
 

--- a/src/main/java/team/rescue/fridge/dto/AuthMember.java
+++ b/src/main/java/team/rescue/fridge/dto/AuthMember.java
@@ -1,0 +1,58 @@
+package team.rescue.fridge.dto;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import team.rescue.fridge.member.entity.Member;
+
+@Getter
+@RequiredArgsConstructor
+public class AuthMember implements UserDetails {
+
+  private Member member;
+
+  public AuthMember(Member member) {
+    this.member = member;
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    Collection<GrantedAuthority> authorities = new ArrayList<>();
+    authorities.add(new SimpleGrantedAuthority(this.member.getRole().name()));
+    return authorities;
+  }
+
+  @Override
+  public String getPassword() {
+    return this.member.getPassword();
+  }
+
+  @Override
+  public String getUsername() {
+    return this.member.getEmail();
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+}

--- a/src/main/java/team/rescue/fridge/dto/LoginDto.java
+++ b/src/main/java/team/rescue/fridge/dto/LoginDto.java
@@ -10,20 +10,20 @@ public class LoginDto {
 
   @Getter
   @Setter
-  public static class Request {
+  public static class LoginReqDto {
     private String email;
     private String password;
   }
 
   @Getter
-  public static class Response {
+  public static class LoginResDto {
 
     private String name;
     private String email;
     private RoleType role;
     private TokenDto tokenDto;
 
-    public Response(Member user, TokenDto token) {
+    public LoginResDto(Member user, TokenDto token) {
       this.name = user.getName();
       this.email = user.getEmail();
       this.role = user.getRole();

--- a/src/main/java/team/rescue/fridge/dto/LoginDto.java
+++ b/src/main/java/team/rescue/fridge/dto/LoginDto.java
@@ -1,0 +1,33 @@
+package team.rescue.fridge.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import team.rescue.fridge.member.entity.Member;
+import team.rescue.fridge.member.entity.RoleType;
+import team.rescue.fridge.security.dto.TokenDto;
+
+public class LoginDto {
+
+  @Getter
+  @Setter
+  public static class Request {
+    private String email;
+    private String password;
+  }
+
+  @Getter
+  public static class Response {
+
+    private String name;
+    private String email;
+    private RoleType role;
+    private TokenDto tokenDto;
+
+    public Response(Member user, TokenDto token) {
+      this.name = user.getName();
+      this.email = user.getEmail();
+      this.role = user.getRole();
+      this.tokenDto = token;
+    }
+  }
+}

--- a/src/main/java/team/rescue/fridge/handler/AuthenticationExceptionHandler.java
+++ b/src/main/java/team/rescue/fridge/handler/AuthenticationExceptionHandler.java
@@ -1,0 +1,26 @@
+package team.rescue.fridge.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+@Slf4j
+@RequiredArgsConstructor
+public class AuthenticationExceptionHandler implements AuthenticationEntryPoint {
+
+
+  @Override
+  public void commence(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException authException) throws IOException, ServletException {
+
+    log.error("[AuthenticationExceptionHandler] 로그인 실패");
+
+    // 유효한 자격증명을 제공하지 않고 접근하려 할때 401
+    response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+  }
+}

--- a/src/main/java/team/rescue/fridge/handler/AuthorizationExceptionHandler.java
+++ b/src/main/java/team/rescue/fridge/handler/AuthorizationExceptionHandler.java
@@ -1,0 +1,23 @@
+package team.rescue.fridge.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+@Slf4j
+public class AuthorizationExceptionHandler implements AccessDeniedHandler {
+
+  @Override
+  public void handle(HttpServletRequest request, HttpServletResponse response,
+      AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+    log.error("[AuthorizationExceptionHandler] 로그인 실패");
+
+    // 필요한 권한이 없이 접근하려 할때 403
+    response.sendError(HttpServletResponse.SC_FORBIDDEN);
+  }
+}

--- a/src/main/java/team/rescue/fridge/member/MemberRepository.java
+++ b/src/main/java/team/rescue/fridge/member/MemberRepository.java
@@ -1,5 +1,6 @@
 package team.rescue.fridge.member;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import team.rescue.fridge.member.entity.Member;
@@ -8,4 +9,6 @@ import team.rescue.fridge.member.entity.Member;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	boolean existsByEmail(String email);
+
+	Optional<Member> findUserByEmail(String email);
 }

--- a/src/main/java/team/rescue/fridge/security/JwtAuthenticationFilter.java
+++ b/src/main/java/team/rescue/fridge/security/JwtAuthenticationFilter.java
@@ -17,8 +17,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import team.rescue.fridge.dto.AuthMember;
-import team.rescue.fridge.dto.LoginDto;
-import team.rescue.fridge.dto.LoginDto.Response;
+import team.rescue.fridge.dto.LoginDto.LoginReqDto;
+import team.rescue.fridge.dto.LoginDto.LoginResDto;
 import team.rescue.fridge.security.dto.TokenDto;
 import team.rescue.fridge.security.token.JwtTokenType;
 
@@ -52,12 +52,12 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     log.debug("로그인 시도 : {}", request.getRequestURL());
 
     try {
-      LoginDto.Request loginDto = objectMapper.readValue(request.getInputStream(),
-          LoginDto.Request.class);
-      log.debug("이메일: {}, 비밀번호: {}", loginDto.getEmail(), loginDto.getPassword());
+      LoginReqDto loginReqDto = objectMapper.readValue(request.getInputStream(),
+          LoginReqDto.class);
+      log.debug("이메일: {}, 비밀번호: {}", loginReqDto.getEmail(), loginReqDto.getPassword());
 
       UsernamePasswordAuthenticationToken authRequestToken =
-          new UsernamePasswordAuthenticationToken(loginDto.getEmail(), loginDto.getPassword());
+          new UsernamePasswordAuthenticationToken(loginReqDto.getEmail(), loginReqDto.getPassword());
 
       return authenticationManager.authenticate(authRequestToken);
 
@@ -89,7 +89,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     redisUtil.put(authMember.getUsername(), refreshToken, REFRESH_TOKEN_EXPIRE_TIME);
 
     TokenDto tokenDto = new TokenDto(accessToken, refreshToken);
-    LoginDto.Response loginResponse = new Response(authMember.getMember(), tokenDto);
+    LoginResDto loginResponse = new LoginResDto(authMember.getMember(), tokenDto);
 
     response.setStatus(HttpStatus.OK.value());
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/team/rescue/fridge/security/JwtAuthenticationFilter.java
+++ b/src/main/java/team/rescue/fridge/security/JwtAuthenticationFilter.java
@@ -1,0 +1,122 @@
+package team.rescue.fridge.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import team.rescue.fridge.dto.AuthMember;
+import team.rescue.fridge.dto.LoginDto;
+import team.rescue.fridge.dto.LoginDto.Response;
+import team.rescue.fridge.security.dto.TokenDto;
+import team.rescue.fridge.security.token.JwtTokenType;
+
+@Slf4j
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+  private static final String LOGIN_PATH = "/api/auth/login";
+  private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24;   // 24h
+
+  private final ObjectMapper objectMapper;
+  private final AuthenticationManager authenticationManager;
+  private final RedisUtil redisUtil;
+
+  public JwtAuthenticationFilter(
+      AuthenticationManager authenticationManager,
+      ObjectMapper objectMapper,
+      RedisUtil redisUtil) {
+
+    setFilterProcessesUrl(LOGIN_PATH);
+    this.authenticationManager = authenticationManager;
+    this.objectMapper = objectMapper;
+    this.redisUtil = redisUtil;
+  }
+
+
+  @Override
+  public Authentication attemptAuthentication(
+      HttpServletRequest request, HttpServletResponse response
+  ) throws AuthenticationException {
+
+    log.debug("로그인 시도 : {}", request.getRequestURL());
+
+    try {
+      LoginDto.Request loginDto = objectMapper.readValue(request.getInputStream(),
+          LoginDto.Request.class);
+      log.debug("이메일: {}, 비밀번호: {}", loginDto.getEmail(), loginDto.getPassword());
+
+      UsernamePasswordAuthenticationToken authRequestToken =
+          new UsernamePasswordAuthenticationToken(loginDto.getEmail(), loginDto.getPassword());
+
+      return authenticationManager.authenticate(authRequestToken);
+
+    } catch (Exception e) {
+      log.error("loginDto 읽기 실패");
+      throw new RuntimeException();
+    }
+  }
+
+  @Override
+  protected void successfulAuthentication(HttpServletRequest request,
+      HttpServletResponse response,
+      FilterChain chain,
+      Authentication authentication) throws IOException {
+
+    log.debug("JwtAuthenticationFilter.successfulAuthentication request={}",
+        request.getRequestURI());
+
+    // 로그인에 성공한 유저
+    final AuthMember authMember = (AuthMember) authentication.getPrincipal();
+
+    // access token 생성
+    String accessToken = JwtTokenProvider.createToken(authMember, JwtTokenType.ACCESS_TOKEN);
+
+    // refresh token 생성
+    String refreshToken = JwtTokenProvider.createToken(authMember, JwtTokenType.REFRESH_TOKEN);
+
+    // redis 저장
+    redisUtil.put(authMember.getUsername(), refreshToken, REFRESH_TOKEN_EXPIRE_TIME);
+
+    TokenDto tokenDto = new TokenDto(accessToken, refreshToken);
+    LoginDto.Response loginResponse = new Response(authMember.getMember(), tokenDto);
+
+    response.setStatus(HttpStatus.OK.value());
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+    // access token, refresh token을 클라이언트에게 전달
+    new ObjectMapper().writeValue(response.getOutputStream(), loginResponse);
+
+  }
+
+  /**
+   * 로그인 인증 실패 시 호출되는 메서드
+   */
+  @Override
+  protected void unsuccessfulAuthentication(
+      HttpServletRequest request, HttpServletResponse response, AuthenticationException failed)
+      throws IOException, ServletException {
+
+    log.error("unsuccessfulAuthentication failed.getLocalizedMessage(): {}",
+        failed.getLocalizedMessage());
+
+    response.setStatus(HttpStatus.UNAUTHORIZED.value());
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("code", HttpStatus.UNAUTHORIZED.value());
+    body.put("error", failed.getMessage());
+
+    new ObjectMapper().writeValue(response.getOutputStream(), body);
+  }
+}

--- a/src/main/java/team/rescue/fridge/security/JwtAuthorizationFilter.java
+++ b/src/main/java/team/rescue/fridge/security/JwtAuthorizationFilter.java
@@ -1,0 +1,89 @@
+package team.rescue.fridge.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.util.ObjectUtils;
+import team.rescue.fridge.dto.AuthMember;
+
+@Slf4j
+public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
+
+  public static final String TOKEN_HEADER = "Authorization";
+  public static final String TOKEN_PREFIX = "Bearer ";
+
+  public JwtAuthorizationFilter(AuthenticationManager authenticationManager) {
+    super(authenticationManager);
+  }
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+
+    log.debug("[{}] JWT 유효성 검사", request.getRequestURI());
+
+    // Access Token Request Header에  없는 경우 인가 처리 하지 않고 다음 필터로
+    String header = request.getHeader(TOKEN_HEADER);
+
+    if (!(header != null && header.startsWith(TOKEN_PREFIX))) {
+      log.debug("[JwtAuthorizationFilter] 토큰이 없음");
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    // Access token from request header(Authorization)
+     String accessToken = (!ObjectUtils.isEmpty(header) && header.startsWith(TOKEN_PREFIX)) ?
+         header.substring(TOKEN_PREFIX.length()) : null;
+
+    // Expired access token
+    if (JwtTokenProvider.isExpiredToken(accessToken)) {
+
+      log.debug("[Expired Access Token] start!");
+
+      // 응답 상태 코드와 컨텐트 타입 설정
+      response.setStatus(HttpStatus.UNAUTHORIZED.value());
+      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+      // 응답 바디 데이터 구성
+      Map<String, Object> body = new HashMap<>();
+//      body.put("code", AuthError.EXPIRED_ACCESS_TOKEN.getHttpStatus());
+//      body.put("error", AuthError.EXPIRED_ACCESS_TOKEN.getErrorMessage());
+      body.put("code", "401 Unauthorized");
+      body.put("error", "만료된 액세스 토큰");
+
+
+      // JSON으로 변환하여 응답 스트림에 작성
+      new ObjectMapper().writeValue(response.getOutputStream(), body);
+
+      // 다음 필터를 타지 않음
+      return;
+    }
+
+    AuthMember authMember = JwtTokenProvider.verify(accessToken);
+
+    // 생성된 AuthUser 객체로 인증된 Authentication 객체 생성
+    Authentication authentication =
+        new UsernamePasswordAuthenticationToken(
+            authMember, null, authMember.getAuthorities()
+        );
+
+    // SecurityContextHolder 저장
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+
+    filterChain.doFilter(request, response);
+  }
+}
+

--- a/src/main/java/team/rescue/fridge/security/JwtTokenProvider.java
+++ b/src/main/java/team/rescue/fridge/security/JwtTokenProvider.java
@@ -1,0 +1,76 @@
+package team.rescue.fridge.security;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import team.rescue.fridge.dto.AuthMember;
+import team.rescue.fridge.member.entity.Member;
+import team.rescue.fridge.member.entity.RoleType;
+import team.rescue.fridge.security.token.JwtTokenType;
+
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtTokenProvider {
+
+  private static final String HEADER = "Authorization";
+  private static final String KEY_ID = "id";
+  private static final String KEY_ROLE = "role";
+  private static String JWT_TOKEN_KEY;
+
+  /**
+   * 토큰 타입에 따라 토큰 생성
+   */
+  public static String createToken(AuthMember authMember, JwtTokenType tokenType) {
+
+    log.debug("[JWT {} 발급] email={}", tokenType.name(), authMember.getUsername());
+
+    Date now = new Date(System.currentTimeMillis());
+    Date expireDate = new Date(now.getTime() + tokenType.getExpireTime());
+
+    return JWT.create()
+        .withSubject(authMember.getUsername())
+        .withIssuedAt(now)
+        .withExpiresAt(expireDate)
+        .withClaim(KEY_ID, authMember.getMember().getId())
+        .withClaim(KEY_ROLE, authMember.getMember().getRole().name())
+        .sign(Algorithm.HMAC512(JWT_TOKEN_KEY));
+  }
+
+  /**
+   * 토큰 검증
+   * <p>검증된 유저의 경우 강제 로그인 처리를 위해 UserDetails 객체를 만들어 반환
+   *
+   * @param token 검증할 토큰
+   * @return 검증된 유저의 UserDetails 객체
+   */
+  public static AuthMember verify(String token) {
+
+    log.debug("start verify token={}", token);
+
+    DecodedJWT decodedJWT =
+        JWT.require(Algorithm.HMAC512(JWT_TOKEN_KEY)).build().verify(token);
+
+    Long id = decodedJWT.getClaim(KEY_ID).asLong();
+    String email = decodedJWT.getSubject();
+    String role = decodedJWT.getClaim(KEY_ROLE).asString();
+
+    Member member = Member.builder()
+        .id(id)
+        .email(email)
+        .role(RoleType.valueOf(role))
+        .build();
+
+    log.debug("role={}", member.getRole());
+    return new AuthMember(member);
+  }
+
+  public static boolean isExpiredToken(String token) {
+    return JWT.decode(token).getExpiresAt().before(new Date(System.currentTimeMillis()));
+  }
+}

--- a/src/main/java/team/rescue/fridge/security/MemberDetailService.java
+++ b/src/main/java/team/rescue/fridge/security/MemberDetailService.java
@@ -1,0 +1,32 @@
+package team.rescue.fridge.security;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+import team.rescue.fridge.dto.AuthMember;
+import team.rescue.fridge.member.MemberRepository;
+import team.rescue.fridge.member.entity.Member;
+
+@Slf4j
+@Component
+public class MemberDetailService implements UserDetailsService {
+  private final MemberRepository memberRepository;
+
+  public MemberDetailService(MemberRepository memberRepository) {
+    this.memberRepository = memberRepository;
+  }
+
+  @Override
+  public UserDetails loadUserByUsername(String userEmail) throws UsernameNotFoundException {
+    log.debug("[+] loadUserByUsername start");
+    Member member = memberRepository.findUserByEmail(userEmail)
+        .orElseThrow(() -> {
+              log.error("Invalid User Email!!");
+              return new RuntimeException();
+            });
+    log.debug(member.getEmail());
+    return new AuthMember(member);
+  }
+}

--- a/src/main/java/team/rescue/fridge/security/RedisUtil.java
+++ b/src/main/java/team/rescue/fridge/security/RedisUtil.java
@@ -1,0 +1,48 @@
+package team.rescue.fridge.security;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RedisUtil {
+
+  private final RedisTemplate<String, Object> redisTemplate;
+
+  @Transactional
+  public void put(String key, Object value, Long expirationTime) {
+    if (expirationTime != null) {
+      redisTemplate.opsForValue().set(key, value, expirationTime, TimeUnit.SECONDS);
+    } else {
+      redisTemplate.opsForValue().set(key, value);
+    }
+  }
+
+  @Transactional
+  public void delete(String key) {
+    redisTemplate.delete(key);
+  }
+
+  public Object get(String key) {
+
+    // key에 해당하는 값이 존재하면 해당 값 반환
+    if (isExists(key)) {
+      return redisTemplate.opsForValue().get(key);
+    } else {
+      return null;
+    }
+  }
+
+  public boolean isExists(String key){
+    return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+  }
+
+  public void setExpireTime(String key, long expirationTime){
+    redisTemplate.expire(key, expirationTime, TimeUnit.SECONDS);
+  }
+
+}

--- a/src/main/java/team/rescue/fridge/security/dto/TokenDto.java
+++ b/src/main/java/team/rescue/fridge/security/dto/TokenDto.java
@@ -1,0 +1,13 @@
+package team.rescue.fridge.security.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TokenDto {
+
+  private final String accessToken;
+  private final String refreshToken;
+
+}

--- a/src/main/java/team/rescue/fridge/security/token/JwtTokenType.java
+++ b/src/main/java/team/rescue/fridge/security/token/JwtTokenType.java
@@ -1,0 +1,14 @@
+package team.rescue.fridge.security.token;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum JwtTokenType {
+  ACCESS_TOKEN(1000 * 60 * 60),               // 1 hour
+  REFRESH_TOKEN(1000 * 60 * 60 * 24 * 7),     // 1 week
+  TEST_TOKEN(1000);                           // 1 sec(for test)
+
+  private final long expireTime;
+}


### PR DESCRIPTION
### 작업 내용 요약 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 변경점
<!---- 실제로 변경된 부분을 작성해주세요. -->
**AS-IS**
**TO-BE**

SecurityConfig에 authorizeHttpRequests를 추가했는데, 추후에 url path, user role이 구체적으로 나오면 더 추가해주면 될것같습니다.

두개의 필터를 사용했습니다. JwtAuthenticationFilter, JwtAuthorizationFilter

JwtAuthenticationFilter 필터는 로그인 시도 시 실행되는 필터이고, 인증되면, access, refresh token을 생성하고, refresh는 redis에도 저장하고 token들을 전달합니다.

JwtAuthorizationFilter 필터는 토큰 검증 시 실행되고, 검증이 완료되면 SecurityContextHolder에 Authentication 객체를 저장합니다.

TokenProvider에서 createToken은 tokenType 파라미터를 보고, access, refresh token을 생성합니다.


### 비고
<!---- 리뷰어에게 하고 싶은 말이나, 참고해야할 부분이 있다면 알려주세요. -->


### 테스트
<!---- 어떤 테스트를 진행했는지 적어주세요.-->

- [ ] 테스트 코드 작성
- [ ] API 테스트 
