### PR TITLE
냉장고 재료 조회, 등록 기능 구현 #20

### DIFF
--- a/src/main/java/team/rescue/fridge/controller/FridgeController.java
+++ b/src/main/java/team/rescue/fridge/controller/FridgeController.java
@@ -1,9 +1,21 @@
 package team.rescue.fridge.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.Errors;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import team.rescue.auth.user.PrincipalDetails;
+import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientAddReqDto;
+import team.rescue.fridge.service.FridgeService;
+import team.rescue.validator.ListValidator;
 
 @Slf4j
 @RestController
@@ -11,4 +23,37 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class FridgeController {
 
+	private final ListValidator listValidator;
+	private final FridgeService fridgeService;
+
+	@GetMapping
+	public ResponseEntity<?> getFridgeIngredients(
+			@AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+		String email = principalDetails.getUsername();
+		return ResponseEntity.ok(fridgeService.getFridgeIngredients(email));
+	}
+
+	@PostMapping("/ingredients")
+	public ResponseEntity<?> addIngredient(
+			@RequestBody List<FridgeIngredientAddReqDto> fridgeIngredientAddDtoList,
+			@AuthenticationPrincipal PrincipalDetails principalDetails, Errors errors) {
+
+		// List<Dto> 형태는 @Valid 어노테이션이 동작하지 않아서
+		// CustomValidator를 생성해서 유효성 검증을 해줘야 함.
+		listValidator.validate(fridgeIngredientAddDtoList, errors);
+
+		if (errors.hasErrors()) {
+			if (errors.getFieldError() != null) {
+				log.error("유효성 검증 실패: {}", errors.getFieldError().getDefaultMessage());
+				return new ResponseEntity<>(errors.getFieldError().getDefaultMessage(),
+						HttpStatus.BAD_REQUEST);
+			}
+		}
+
+		String email = principalDetails.getUsername();
+
+		return ResponseEntity.ok(fridgeService.addIngredient(email, fridgeIngredientAddDtoList));
+
+	}
 }

--- a/src/main/java/team/rescue/fridge/dto/FridgeDto.java
+++ b/src/main/java/team/rescue/fridge/dto/FridgeDto.java
@@ -1,0 +1,16 @@
+package team.rescue.fridge.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientResDto;
+
+@Getter
+@Setter
+@Builder
+public class FridgeDto {
+
+	private Long id;
+	private List<FridgeIngredientResDto> fridgeIngredientResDtoList;
+}

--- a/src/main/java/team/rescue/fridge/dto/FridgeIngredientDto.java
+++ b/src/main/java/team/rescue/fridge/dto/FridgeIngredientDto.java
@@ -1,0 +1,45 @@
+package team.rescue.fridge.dto;
+
+import jakarta.validation.constraints.Future;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import team.rescue.fridge.entity.FridgeIngredient;
+
+public class FridgeIngredientDto {
+
+	@Getter
+	@Setter
+	@Builder
+	public static class FridgeIngredientAddReqDto {
+
+		private String name;
+
+		private String memo;
+
+		@Future(message = "유통기한이 이미 지난 재료입니다.")
+		private LocalDateTime expiredAt;
+	}
+
+	@Getter
+	@Setter
+	@Builder
+	public static class FridgeIngredientResDto {
+
+		private Long id;
+		private String name;
+		private String memo;
+		private LocalDateTime expiredAt;
+
+		public static FridgeIngredientResDto of(FridgeIngredient fridgeIngredient) {
+			return FridgeIngredientResDto.builder()
+					.id(fridgeIngredient.getId())
+					.name(fridgeIngredient.getName())
+					.memo(fridgeIngredient.getMemo())
+					.expiredAt(fridgeIngredient.getExpiredAt())
+					.build();
+		}
+	}
+
+}

--- a/src/main/java/team/rescue/fridge/repository/FridgeIngredientRepository.java
+++ b/src/main/java/team/rescue/fridge/repository/FridgeIngredientRepository.java
@@ -1,0 +1,16 @@
+package team.rescue.fridge.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import team.rescue.fridge.entity.Fridge;
+import team.rescue.fridge.entity.FridgeIngredient;
+
+@Repository
+public interface FridgeIngredientRepository extends JpaRepository<FridgeIngredient, Long> {
+
+	boolean existsByNameAndMemoAndExpiredAt(String name, String memo, LocalDateTime expiredAt);
+
+	List<FridgeIngredient> findByFridge(Fridge fridge);
+}

--- a/src/main/java/team/rescue/fridge/repository/FridgeRepository.java
+++ b/src/main/java/team/rescue/fridge/repository/FridgeRepository.java
@@ -1,10 +1,13 @@
 package team.rescue.fridge.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import team.rescue.fridge.entity.Fridge;
+import team.rescue.member.entity.Member;
 
 @Repository
 public interface FridgeRepository extends JpaRepository<Fridge, Long> {
+	Optional<Fridge> findByMember(Member member);
 
 }

--- a/src/main/java/team/rescue/fridge/service/FridgeService.java
+++ b/src/main/java/team/rescue/fridge/service/FridgeService.java
@@ -1,11 +1,20 @@
 package team.rescue.fridge.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.rescue.fridge.dto.FridgeDto;
+import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientAddReqDto;
+import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientResDto;
 import team.rescue.fridge.entity.Fridge;
+import team.rescue.fridge.entity.FridgeIngredient;
+import team.rescue.fridge.repository.FridgeIngredientRepository;
 import team.rescue.fridge.repository.FridgeRepository;
+import team.rescue.member.entity.Member;
+import team.rescue.member.repository.MemberRepository;
 
 @Slf4j
 @Service
@@ -14,6 +23,8 @@ import team.rescue.fridge.repository.FridgeRepository;
 public class FridgeService {
 
 	private final FridgeRepository fridgeRepository;
+	private final MemberRepository memberRepository;
+	private final FridgeIngredientRepository fridgeIngredientRepository;
 
 
 	/**
@@ -26,6 +37,81 @@ public class FridgeService {
 	public Fridge createFridge() {
 
 		return fridgeRepository.save(Fridge.builder().build());
+	}
+
+	/**
+	 * <p>냉장고 재료를 조회하는 메소드
+	 *
+	 * @param email
+	 * @return
+	 */
+	public FridgeDto getFridgeIngredients(String email) {
+		Member member = memberRepository.findUserByEmail(email)
+				.orElseThrow(() -> {
+					log.error("일치하는 사용자 정보 없음");
+					return new RuntimeException();
+				});
+
+		Fridge fridge = fridgeRepository.findByMember(member)
+				.orElseThrow(() -> {
+					log.error("해당 회원은 냉장고가 없음");
+					return new RuntimeException();
+				});
+
+		List<FridgeIngredient> fridgeIngredients = fridgeIngredientRepository.findByFridge(fridge);
+		List<FridgeIngredientResDto> fridgeIngredientResDtoList = fridgeIngredients.stream()
+				.map(FridgeIngredientResDto::of)
+				.collect(Collectors.toList());
+
+		return FridgeDto.builder()
+				.id(fridge.getId())
+				.fridgeIngredientResDtoList(fridgeIngredientResDtoList)
+				.build();
+	}
+
+	/**
+	 * <p>입력받은 리스트를 순회하면서 냉장고에 재료를 저장
+	 * 이름, 메모, 유통기한이 모두 동일한 재료가 두 번 입력되는 경우 재료 등록 처리 하지 않음
+	 *
+	 * @param email
+	 * @param fridgeIngredientAddReqDtoList
+	 * @return
+	 */
+	@Transactional
+	public List<FridgeIngredientResDto> addIngredient(String email,
+			List<FridgeIngredientAddReqDto> fridgeIngredientAddReqDtoList) {
+		Member member = memberRepository.findUserByEmail(email)
+				.orElseThrow(() -> {
+					log.error("일치하는 사용자 정보 없음");
+					return new RuntimeException();
+				});
+
+		Fridge fridge = fridgeRepository.findByMember(member)
+				.orElseThrow(() -> {
+					log.error("해당 회원은 냉장고가 없음");
+					return new RuntimeException();
+				});
+
+		for (FridgeIngredientAddReqDto fridgeIngredientAddReqDto : fridgeIngredientAddReqDtoList) {
+			if (!fridgeIngredientRepository.existsByNameAndMemoAndExpiredAt(
+					fridgeIngredientAddReqDto.getName(),
+					fridgeIngredientAddReqDto.getMemo(),
+					fridgeIngredientAddReqDto.getExpiredAt())) {
+
+				FridgeIngredient fridgeIngredient = FridgeIngredient.builder()
+						.fridge(fridge)
+						.name(fridgeIngredientAddReqDto.getName())
+						.memo(fridgeIngredientAddReqDto.getMemo())
+						.expiredAt(fridgeIngredientAddReqDto.getExpiredAt())
+						.build();
+
+				fridgeIngredientRepository.save(fridgeIngredient);
+			}
+		}
+
+		List<FridgeIngredient> fridgeIngredients = fridgeIngredientRepository.findByFridge(fridge);
+		return fridgeIngredients.stream().map(FridgeIngredientResDto::of)
+				.collect(Collectors.toList());
 	}
 
 }

--- a/src/main/java/team/rescue/validator/ListValidator.java
+++ b/src/main/java/team/rescue/validator/ListValidator.java
@@ -1,0 +1,29 @@
+package team.rescue.validator;
+
+import java.util.Collection;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
+
+@Component
+@RequiredArgsConstructor
+public class ListValidator implements Validator {
+
+	private final SpringValidatorAdapter validator;
+
+	@Override
+	public boolean supports(Class<?> clazz) {
+		return List.class.equals(clazz);
+	}
+
+	@Override
+	public void validate(Object target, Errors errors) {
+		for (Object object : (Collection) target) {
+			validator.validate(object, errors);
+		}
+
+	}
+}


### PR DESCRIPTION
### 작업 내용 요약 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 변경점
<!---- 실제로 변경된 부분을 작성해주세요. -->
**AS-IS**

**TO-BE**
- 냉장고 재료 등록, 조회 기능 구현했습니다.
- 현재 로그인을 했을 때 냉장고가 만들어져 있지 않아서 임의로 데이터베이스에 냉장고 추가해서 테스트 진행했습니다.
- 재료 등록할 때 List로 받는데 `@Valid` 어노테이션은 Java Beans에만 적용이 되기 때문에 Llist<Dto> 형태에는 적용이 안된다고 하여 커스텀 validator인 `ListValidator` 구현했습니다. 현재 Controller에서 errors로 처리하는데 @ControllerAdvice로 처리할 예정이면 나중에 수정해야 할 것 같습니다. 
- 재료 등록 시 이름, 메모, 유통기한이 모두 동일한 재료를 입력했을 때는 추가되지 않도록 구현했습니다. (이름은 같지만 유통기한이 다르다던지, 이름은 같지만 메모가 다른 경우를 관리할 수도 있다고 판단)
### 비고
<!---- 리뷰어에게 하고 싶은 말이나, 참고해야할 부분이 있다면 알려주세요. -->
제가 놓친 부분이 있는 지 확인해주세요!

### 테스트
<!---- 어떤 테스트를 진행했는지 적어주세요.-->

- [ ] 테스트 코드 작성
- [ ] API 테스트 
