### PR TITLE
레시피 리뷰 등록, 조회 기능 구현 #1

### DIFF
--- a/src/main/java/team/rescue/common/dto/ImageDto.java
+++ b/src/main/java/team/rescue/common/dto/ImageDto.java
@@ -1,0 +1,34 @@
+package team.rescue.common.dto;
+
+import java.io.IOException;
+import java.io.InputStream;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.core.io.Resource;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+public class ImageDto {
+
+	private String name;
+	private String originFilename;
+	private Resource resource;
+	private InputStream inputStream;
+	private byte[] bytes;
+	private String contentType;
+	private long size;
+	private String url;
+
+
+	public ImageDto(MultipartFile image) throws IOException {
+
+		this.name = image.getName();
+		this.originFilename = image.getOriginalFilename();
+		this.resource = image.getResource();
+		this.inputStream = image.getInputStream();
+		this.bytes = image.getBytes();
+		this.contentType = image.getContentType();
+		this.size = image.getSize();
+	}
+}

--- a/src/main/java/team/rescue/common/file/FileService.java
+++ b/src/main/java/team/rescue/common/file/FileService.java
@@ -10,8 +10,13 @@ import team.rescue.common.dto.ImageDto;
 @Service
 public class FileService {
 
-	// TODO: 이후 이미지 리사이징 후 S3 업로드 로직으로 변경
-	// 현재는 이름값만 반환
+	/**
+	 * 이미지 S3 저장
+	 * TODO: 현재 이미지 originName을 반환하도록 임시 처리, 이후 실제 로직 구현 필요
+	 *
+	 * @param image S3 버킷에 저장할 이미지 파일
+	 * @return S3 URL
+	 */
 	public String uploadImageToS3(MultipartFile image) {
 
 		log.info("[S3 이미지 업로드]");

--- a/src/main/java/team/rescue/common/file/FileService.java
+++ b/src/main/java/team/rescue/common/file/FileService.java
@@ -1,0 +1,31 @@
+package team.rescue.common.file;
+
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import team.rescue.common.dto.ImageDto;
+
+@Slf4j
+@Service
+public class FileService {
+
+	// TODO: 이후 이미지 리사이징 후 S3 업로드 로직으로 변경
+	// 현재는 이름값만 반환
+	public String uploadImageToS3(MultipartFile image) {
+
+		log.info("[S3 이미지 업로드]");
+
+		if (image.isEmpty()) {
+			return null;
+		}
+
+		try {
+			ImageDto imageDto = new ImageDto(image);
+
+			return imageDto.getOriginFilename();
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/src/main/java/team/rescue/config/SecurityConfig.java
+++ b/src/main/java/team/rescue/config/SecurityConfig.java
@@ -60,9 +60,7 @@ public class SecurityConfig {
 
 		http.authorizeHttpRequests(request -> {
 
-			request.requestMatchers("/api/auth/email/join").permitAll();
-			request.requestMatchers("/api/auth/email/login").permitAll();
-			request.requestMatchers("/api/auth/oauth").permitAll();
+			request.requestMatchers("/api/**").permitAll();
 
 			request.dispatcherTypeMatchers(DispatcherType.FORWARD).permitAll();
 			request.anyRequest().authenticated();
@@ -125,7 +123,8 @@ public class SecurityConfig {
 					AuthenticationManager.class);
 
 			builder.addFilter(
-					new JwtAuthenticationFilter(authenticationManager, objectMapper, redisUtil, memberRepository));
+					new JwtAuthenticationFilter(authenticationManager, objectMapper, redisUtil,
+							memberRepository));
 			builder.addFilter(new JwtAuthorizationFilter(authenticationManager));
 			super.configure(builder);
 		}

--- a/src/main/java/team/rescue/cook/repository/CookRepository.java
+++ b/src/main/java/team/rescue/cook/repository/CookRepository.java
@@ -1,0 +1,8 @@
+package team.rescue.cook.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.rescue.cook.entity.Cook;
+
+public interface CookRepository extends JpaRepository<Cook, Long> {
+
+}

--- a/src/main/java/team/rescue/error/GlobalExceptionHandler.java
+++ b/src/main/java/team/rescue/error/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import team.rescue.common.dto.ResponseDto;
+import team.rescue.error.exception.ServiceException;
 import team.rescue.error.exception.UserException;
 import team.rescue.error.exception.ValidationException;
 
@@ -23,6 +24,25 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<?> userException(UserException e) {
 
 		log.error(e.getErrorMessage());
+
+		ResponseDto<?> response = ResponseDto.builder()
+				.code(e.getCode())
+				.message(e.getErrorMessage())
+				.data(null).build();
+
+		return new ResponseEntity<>(response, e.getStatusCode());
+	}
+
+	/**
+	 * 서비스(비즈니스) 로직 관련 에러 핸들링
+	 *
+	 * @param e ServiceException
+	 * @return Error Response with custom UserException Status Code
+	 */
+	@ExceptionHandler(ServiceException.class)
+	public ResponseEntity<?> userException(ServiceException e) {
+
+		log.error(e.getMessage());
 
 		ResponseDto<?> response = ResponseDto.builder()
 				.code(e.getCode())

--- a/src/main/java/team/rescue/error/exception/ServiceException.java
+++ b/src/main/java/team/rescue/error/exception/ServiceException.java
@@ -1,0 +1,20 @@
+package team.rescue.error.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import team.rescue.error.type.ServiceError;
+
+@Getter
+public class ServiceException extends RuntimeException {
+
+	int code;
+	HttpStatus statusCode;
+	String errorMessage;
+
+	public ServiceException(ServiceError serviceError) {
+		this.code = serviceError.getCode();
+		this.statusCode = serviceError.getHttpStatus();
+		this.errorMessage = serviceError.getErrorMessage();
+	}
+
+}

--- a/src/main/java/team/rescue/error/exception/UserException.java
+++ b/src/main/java/team/rescue/error/exception/UserException.java
@@ -4,6 +4,10 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 import team.rescue.error.type.UserError;
 
+/**
+ * TODO: RuntimeException을 extend 하는 전체 서비스 커스텀 에러 하나만 남기도록 작업 필요
+ * BuisnessException에 포함 처리
+ */
 @Getter
 public class UserException extends RuntimeException {
 

--- a/src/main/java/team/rescue/error/type/ReviewError.java
+++ b/src/main/java/team/rescue/error/type/ReviewError.java
@@ -1,0 +1,20 @@
+package team.rescue.error.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 리뷰 관련 에러
+ * <p> code: 프론트 규약 에러 코드(HTTP Status Code로 구분 불가한 경우)
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ReviewError {
+
+	NOT_FOUND_REVIEW(-1, HttpStatus.NOT_FOUND, "이미 삭제된 리뷰입니다.");
+
+	private final int code;
+	private final HttpStatus httpStatus;
+	private final String errorMessage;
+}

--- a/src/main/java/team/rescue/error/type/ServiceError.java
+++ b/src/main/java/team/rescue/error/type/ServiceError.java
@@ -1,0 +1,20 @@
+package team.rescue.error.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 비즈니스 로직 관련 에러
+ * <p> code: 프론트 규약 에러 코드(HTTP Status Code로 구분 불가한 경우)
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ServiceError {
+
+	NOT_FOUND_RECIPE(-1, HttpStatus.NOT_FOUND, "이미 삭제된 레시피입니다.");
+
+	private final int code;
+	private final HttpStatus httpStatus;
+	private final String errorMessage;
+}

--- a/src/main/java/team/rescue/recipe/dto/RecipeDto.java
+++ b/src/main/java/team/rescue/recipe/dto/RecipeDto.java
@@ -1,0 +1,28 @@
+package team.rescue.recipe.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import team.rescue.member.dto.MemberDto.MemberInfoDto;
+import team.rescue.recipe.entity.Recipe;
+
+public class RecipeDto {
+
+	@Getter
+	@Setter
+	public static class RecipeInfoDto {
+
+		private Long id;
+		private String title;
+		private MemberInfoDto author;
+
+		public static RecipeInfoDto fromEntity(Recipe recipe) {
+			RecipeInfoDto recipeInfo = new RecipeInfoDto();
+			recipeInfo.setId(recipe.getId());
+			recipeInfo.setTitle(recipe.getTitle());
+			recipeInfo.setAuthor(MemberInfoDto.fromEntity(recipe.getMember()));
+
+			return recipeInfo;
+		}
+	}
+
+}

--- a/src/main/java/team/rescue/recipe/repository/RecipeRepository.java
+++ b/src/main/java/team/rescue/recipe/repository/RecipeRepository.java
@@ -1,0 +1,8 @@
+package team.rescue.recipe.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.rescue.recipe.entity.Recipe;
+
+public interface RecipeRepository extends JpaRepository<Recipe, Long> {
+
+}

--- a/src/main/java/team/rescue/review/controller/ReviewController.java
+++ b/src/main/java/team/rescue/review/controller/ReviewController.java
@@ -6,6 +6,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import team.rescue.auth.user.PrincipalDetails;
 import team.rescue.common.dto.ResponseDto;
+import team.rescue.review.dto.ReviewDto.ReviewDetailDto;
 import team.rescue.review.dto.ReviewDto.ReviewInfoDto;
 import team.rescue.review.dto.ReviewDto.ReviewReqDto;
 import team.rescue.review.service.ReviewService;
@@ -47,10 +50,30 @@ public class ReviewController {
 		ReviewInfoDto reviewInfo = reviewService.createReview(data, image, details);
 
 		return new ResponseEntity<>(
-				ResponseDto.builder().data(reviewInfo).message("레시피 리뷰가 정상적으로 등록되었습니다.").build(),
+				new ResponseDto<>(1, "레시피 리뷰가 등록되었습니다.", reviewInfo),
 				HttpStatus.CREATED
 		);
 
+	}
+
+	/**
+	 * 특정 리뷰 상세 조회
+	 *
+	 * @param reviewId 조회할 리뷰 아이디
+	 * @return 해당 리뷰 상세 DTO
+	 */
+	@GetMapping("/{reviewId}")
+	@PreAuthorize("permitAll()")
+	public ResponseEntity<ResponseDto<ReviewDetailDto>> getReviewDetail(
+			@PathVariable Long reviewId
+	) {
+
+		ReviewDetailDto reviewDetailDto = reviewService.getReview(reviewId);
+
+		return new ResponseEntity<>(
+				new ResponseDto<>(1, null, reviewDetailDto),
+				HttpStatus.CREATED
+		);
 	}
 
 }

--- a/src/main/java/team/rescue/review/controller/ReviewController.java
+++ b/src/main/java/team/rescue/review/controller/ReviewController.java
@@ -2,13 +2,47 @@ package team.rescue.review.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import team.rescue.auth.user.PrincipalDetails;
+import team.rescue.common.dto.ResponseDto;
+import team.rescue.review.dto.ReviewDto.ReviewInfoDto;
+import team.rescue.review.dto.ReviewDto.ReviewReqDto;
+import team.rescue.review.service.ReviewService;
 
 @Slf4j
 @RestController
 @RequestMapping("/api/reviews")
 @RequiredArgsConstructor
 public class ReviewController {
+
+	private final ReviewService reviewService;
+
+	@PostMapping
+	@PreAuthorize("hasAuthority('USER')")
+	public ResponseEntity<?> createReview(
+			@RequestPart ReviewReqDto data,
+			@RequestPart MultipartFile image,
+			@AuthenticationPrincipal PrincipalDetails details
+	) {
+
+		log.info("[리뷰 업르드] recipeId={}, title={}, imageOriginFileName={}", data.getRecipeId(),
+				data.getTitle(), image.getOriginalFilename());
+
+		ReviewInfoDto reviewInfo = reviewService.createReview(data, image, details);
+
+		return new ResponseEntity<>(
+				ResponseDto.builder().data(reviewInfo).message("레시피 리뷰가 정상적으로 등록되었습니다.").build(),
+				HttpStatus.CREATED
+		);
+
+	}
 
 }

--- a/src/main/java/team/rescue/review/controller/ReviewController.java
+++ b/src/main/java/team/rescue/review/controller/ReviewController.java
@@ -25,6 +25,14 @@ public class ReviewController {
 
 	private final ReviewService reviewService;
 
+	/**
+	 * 리뷰 등록
+	 *
+	 * @param data    리뷰 등록 요청 데이터
+	 * @param image   리뷰 사진
+	 * @param details 로그인 유저
+	 * @return 생성된 리뷰 요약 데이터
+	 */
 	@PostMapping
 	@PreAuthorize("hasAuthority('USER')")
 	public ResponseEntity<?> createReview(

--- a/src/main/java/team/rescue/review/dto/ReviewDto.java
+++ b/src/main/java/team/rescue/review/dto/ReviewDto.java
@@ -3,6 +3,7 @@ package team.rescue.review.dto;
 import lombok.Getter;
 import lombok.Setter;
 import team.rescue.member.dto.MemberDto.MemberInfoDto;
+import team.rescue.recipe.dto.RecipeDto.RecipeInfoDto;
 import team.rescue.review.entity.Review;
 
 public class ReviewDto {
@@ -26,7 +27,7 @@ public class ReviewDto {
 		private Long id;
 		private String title;
 		private String imageUrl;
-		private MemberInfoDto member;
+		private MemberInfoDto author;
 
 		public static ReviewInfoDto fromEntity(Review review) {
 
@@ -34,7 +35,7 @@ public class ReviewDto {
 			reviewInfo.setId(review.getId());
 			reviewInfo.setTitle(review.getTitle());
 			reviewInfo.setImageUrl(review.getImageUrl());
-			reviewInfo.setMember(MemberInfoDto.fromEntity(review.getMember()));
+			reviewInfo.setAuthor(MemberInfoDto.fromEntity(review.getMember()));
 
 			return reviewInfo;
 		}
@@ -44,6 +45,26 @@ public class ReviewDto {
 	@Getter
 	@Setter
 	public static class ReviewDetailDto {
+
+		private Long id;
+		private String title;
+		private String imageUrl;
+		private String contents;
+		private MemberInfoDto author;
+		private RecipeInfoDto recipe;
+
+		public static ReviewDetailDto fromEntity(Review review) {
+
+			ReviewDetailDto reviewDetail = new ReviewDetailDto();
+			reviewDetail.setId(review.getId());
+			reviewDetail.setTitle(review.getTitle());
+			reviewDetail.setImageUrl(review.getImageUrl());
+			reviewDetail.setContents(review.getContents());
+			reviewDetail.setAuthor(MemberInfoDto.fromEntity(review.getMember()));
+			reviewDetail.setRecipe(RecipeInfoDto.fromEntity(review.getRecipe()));
+
+			return reviewDetail;
+		}
 
 	}
 

--- a/src/main/java/team/rescue/review/dto/ReviewDto.java
+++ b/src/main/java/team/rescue/review/dto/ReviewDto.java
@@ -1,0 +1,50 @@
+package team.rescue.review.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import team.rescue.member.dto.MemberDto.MemberInfoDto;
+import team.rescue.review.entity.Review;
+
+public class ReviewDto {
+
+	@Getter
+	@Setter
+	public static class ReviewReqDto {
+
+		// TODO: Valid 추가 필요
+
+		private Long recipeId;
+		private Long cookId;
+		private String title;
+		private String contents;
+	}
+
+	@Getter
+	@Setter
+	public static class ReviewInfoDto {
+
+		private Long id;
+		private String title;
+		private String imageUrl;
+		private MemberInfoDto member;
+
+		public static ReviewInfoDto fromEntity(Review review) {
+
+			ReviewInfoDto reviewInfo = new ReviewInfoDto();
+			reviewInfo.setId(review.getId());
+			reviewInfo.setTitle(review.getTitle());
+			reviewInfo.setImageUrl(review.getImageUrl());
+			reviewInfo.setMember(MemberInfoDto.fromEntity(review.getMember()));
+
+			return reviewInfo;
+		}
+
+	}
+
+	@Getter
+	@Setter
+	public static class ReviewDetailDto {
+
+	}
+
+}

--- a/src/main/java/team/rescue/review/entity/Review.java
+++ b/src/main/java/team/rescue/review/entity/Review.java
@@ -45,18 +45,18 @@ public class Review {
 	@JoinColumn(name = "recipe_id")
 	private Recipe recipe;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "cook_id")
+	private Cook cook;
+
 	@Column(name = "title", nullable = false, length = 50)
 	private String title;
 
 	@Column(name = "review_image_url")
-	private String image_url;
+	private String imageUrl;
 
 	@Column(name = "contents", nullable = false, length = 1000)
 	private String contents;
-
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "cook_id")
-	private Cook cook;
 
 	@CreatedDate
 	@Column(name = "created_at", nullable = false)

--- a/src/main/java/team/rescue/review/repository/ReviewRepository.java
+++ b/src/main/java/team/rescue/review/repository/ReviewRepository.java
@@ -1,0 +1,8 @@
+package team.rescue.review.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.rescue.review.entity.Review;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+}

--- a/src/main/java/team/rescue/review/service/ReviewService.java
+++ b/src/main/java/team/rescue/review/service/ReviewService.java
@@ -23,7 +23,6 @@ import team.rescue.review.repository.ReviewRepository;
 
 @Slf4j
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ReviewService {
 
@@ -34,6 +33,14 @@ public class ReviewService {
 	private final FileService fileService;
 
 
+	/**
+	 * 리뷰 등록
+	 *
+	 * @param reviewReqDto 리뷰 등록 요청 데이터
+	 * @param image        리뷰 이미지 파일
+	 * @param details      Principal
+	 * @return 등록 리뷰 요약 데이터 DTO
+	 */
 	@Transactional
 	public ReviewInfoDto createReview(
 			ReviewReqDto reviewReqDto,

--- a/src/main/java/team/rescue/review/service/ReviewService.java
+++ b/src/main/java/team/rescue/review/service/ReviewService.java
@@ -4,11 +4,67 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import team.rescue.auth.user.PrincipalDetails;
+import team.rescue.common.file.FileService;
+import team.rescue.cook.entity.Cook;
+import team.rescue.cook.repository.CookRepository;
+import team.rescue.error.exception.UserException;
+import team.rescue.error.type.UserError;
+import team.rescue.member.entity.Member;
+import team.rescue.member.repository.MemberRepository;
+import team.rescue.recipe.entity.Recipe;
+import team.rescue.recipe.repository.RecipeRepository;
+import team.rescue.review.dto.ReviewDto.ReviewDetailDto;
+import team.rescue.review.dto.ReviewDto.ReviewInfoDto;
+import team.rescue.review.dto.ReviewDto.ReviewReqDto;
+import team.rescue.review.entity.Review;
+import team.rescue.review.repository.ReviewRepository;
 
 @Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ReviewService {
+
+	private final ReviewRepository reviewRepository;
+	private final MemberRepository memberRepository;
+	private final CookRepository cookRepository;
+	private final RecipeRepository recipeRepository;
+	private final FileService fileService;
+
+
+	@Transactional
+	public ReviewInfoDto createReview(
+			ReviewReqDto reviewReqDto,
+			MultipartFile image,
+			PrincipalDetails details
+	) {
+
+		log.info("[리뷰 생성]");
+
+		Member member = memberRepository.findUserByEmail(details.getMember().getEmail())
+				.orElseThrow(() -> new UserException(UserError.NOT_FOUND_USER));
+
+		Cook cook = cookRepository.getReferenceById(reviewReqDto.getCookId());
+		Recipe recipe = recipeRepository.getReferenceById(reviewReqDto.getRecipeId());
+
+		Review review = Review.builder()
+				.member(member)
+				.recipe(recipe)
+				.cook(cook)
+				.title(reviewReqDto.getTitle())
+				.contents(reviewReqDto.getContents())
+				.imageUrl(fileService.uploadImageToS3(image))
+				.build();
+
+		return ReviewInfoDto.fromEntity(reviewRepository.save(review));
+	}
+
+	public ReviewDetailDto readReview() {
+
+		return null;
+	}
+
 
 }

--- a/src/main/java/team/rescue/review/service/ReviewService.java
+++ b/src/main/java/team/rescue/review/service/ReviewService.java
@@ -9,7 +9,9 @@ import team.rescue.auth.user.PrincipalDetails;
 import team.rescue.common.file.FileService;
 import team.rescue.cook.entity.Cook;
 import team.rescue.cook.repository.CookRepository;
+import team.rescue.error.exception.ServiceException;
 import team.rescue.error.exception.UserException;
+import team.rescue.error.type.ServiceError;
 import team.rescue.error.type.UserError;
 import team.rescue.member.entity.Member;
 import team.rescue.member.repository.MemberRepository;
@@ -68,10 +70,19 @@ public class ReviewService {
 		return ReviewInfoDto.fromEntity(reviewRepository.save(review));
 	}
 
-	public ReviewDetailDto readReview() {
+	/**
+	 * 특정 리뷰 상세 조회
+	 *
+	 * @param reviewId 조회할 리뷰 ID
+	 * @return 리뷰 상세 DTO
+	 */
+	@Transactional(readOnly = true)
+	public ReviewDetailDto getReview(Long reviewId) {
 
-		return null;
+		log.info("[리뷰 상세 조회]");
+		Review review = reviewRepository.findById(reviewId)
+				.orElseThrow(() -> new ServiceException(ServiceError.NOT_FOUND_RECIPE));
+
+		return ReviewDetailDto.fromEntity(review);
 	}
-
-
 }


### PR DESCRIPTION
### 작업 내용 요약 
- 레시피 리뷰 등록 기능 구현
- 레시피 리뷰 조회 기능 구현

### 변경점
<!---- 실제로 변경된 부분을 작성해주세요. -->
**AS-IS**


**TO-BE**
1. 레시피 리뷰 등록 기능 구현 및 레시피 리뷰 조회 기능 구현
  - ReviewDTO에 포함하기 위해 다른 Domain의 DTO를 생성해 두었습니다. 
  - 이 부분이 다른 작업과 겹칠 수 있으므로 병합 시 확인 부탁드립니다.
2. #70 
공통 ResponseDTO 부분 Builder로 생성할 수 있도록 처리해뒀는데, 
이 경우 Generic으로 지정한 부분이 타입 추론 부분이라 builder로 생성하는 경우 Object로 인식되어
Controller 단에서 ResponseEntity<?>로 와일드카드 설정하지 않고 타입을 명시해주면 사용이 불가합니다.
지금 PR에서는 생성자로 ResponseDto를 생성하도록 변경해 두었는데, 이 부분은 추후에 일괄 수정하겠습니다. 
3. #71 
각 도메인별로 Error Enum 정의하고 RuntimeException을 extends한 커스텀 에러를 생성하는 쪽으로 구현해두었는데
서비스단에서 발생하는 예외는 대부분 RuntimeException을 extends 하므로 굳이 도메인 별로 나눌 필요가 없을 것 같아서
ServiceException과 ServiceError로 합치는 것이 나을 것 같습니다. 우선 변경점을 최소화하기 위해 지금 PR에서 
ServiceException과 ServiceError를 작성해두고, 기존 에러 정의는 수정하지 않았습니다. 이 부분도 일괄 수정하겠습니다. 

### 비고


### 테스트
<!---- 어떤 테스트를 진행했는지 적어주세요.-->

- [ ] 테스트 코드 작성
- [ ] API 테스트 
