### PR TITLE
냉장고 재료 수정 및 삭제 기능 구현 #32

### DIFF
--- a/src/main/java/team/rescue/error/GlobalExceptionHandler.java
+++ b/src/main/java/team/rescue/error/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import team.rescue.common.dto.ResponseDto;
+import team.rescue.error.exception.AuthException;
 import team.rescue.error.exception.ServiceException;
 import team.rescue.error.exception.ValidationException;
 
@@ -13,6 +14,24 @@ import team.rescue.error.exception.ValidationException;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+
+	/**
+	 * 인증 관련 에러 핸들링
+	 *
+	 * @param e AuthException
+	 * @return Error Response with custom AuthException Status Code
+	 */
+	@ExceptionHandler(AuthException.class)
+	public ResponseEntity<?> authException(AuthException e) {
+
+		log.error(e.getErrorMessage());
+
+		ResponseDto<?> response = ResponseDto.builder()
+				.message(e.getErrorMessage())
+				.data(null).build();
+
+		return new ResponseEntity<>(response, e.getHttpStatus());
+	}
 
 	/**
 	 * 서비스(비즈니스) 로직 관련 에러 핸들링

--- a/src/main/java/team/rescue/error/type/AuthError.java
+++ b/src/main/java/team/rescue/error/type/AuthError.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AuthError {
 
+	NEED_LOGIN(HttpStatus.UNAUTHORIZED, "로그인이 필요한 서비스입니다."),
 	AUTHENTICATION_FAILURE(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다. 아이디와 비밀번호를 확인해주세요."),
 	ACCESS_DENIED(HttpStatus.FORBIDDEN, "권한이 없습니다."),
 	EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다.");

--- a/src/main/java/team/rescue/error/type/ServiceError.java
+++ b/src/main/java/team/rescue/error/type/ServiceError.java
@@ -25,12 +25,14 @@ public enum ServiceError {
 	EMAIL_CODE_MIS_MATCH(HttpStatus.BAD_REQUEST, "이메일 인증 코드가 일치하지 않습니다."),
 
 	// Recipe
-	RECIPE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미 삭제된 레시피입니다."),
+	RECIPE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 레시피를 찾을 수 없습니다."),
 
 	// Fridge
-	FRIDGE_NOT_FOUND(HttpStatus.NOT_FOUND, "냉장고 정보가 없습니다.");
+	FRIDGE_NOT_FOUND(HttpStatus.NOT_FOUND, "냉장고 정보가 없습니다."),
 
-	
+	// FridgeIngredient
+	INGREDIENT_NOT_FOUND(HttpStatus.NOT_FOUND, "재료 정보가 없습니다.");
+
 	private final HttpStatus httpStatus;
 	private final String errorMessage;
 }

--- a/src/main/java/team/rescue/fridge/controller/FridgeController.java
+++ b/src/main/java/team/rescue/fridge/controller/FridgeController.java
@@ -18,8 +18,8 @@ import team.rescue.common.dto.ResponseDto;
 import team.rescue.error.exception.ValidationException;
 import team.rescue.fridge.dto.FridgeDto;
 import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientCreateDto;
-import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientEditDto;
 import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientInfoDto;
+import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientUpdateDto;
 import team.rescue.fridge.service.FridgeService;
 import team.rescue.validator.ListValidator;
 
@@ -85,13 +85,13 @@ public class FridgeController {
 	@PutMapping("/ingredients")
 	@PreAuthorize("hasAuthority('USER')")
 	public ResponseEntity<ResponseDto<List<FridgeIngredientInfoDto>>> editIngredient(
-			@RequestBody FridgeIngredientEditDto fridgeIngredientEditDto,
+			@RequestBody FridgeIngredientUpdateDto fridgeIngredientUpdateDto,
 			@AuthenticationPrincipal PrincipalDetails principalDetails
 	) {
 
 		String email = principalDetails.getUsername();
 		List<FridgeIngredientInfoDto> fridgeIngredientInfoDtoList =
-				fridgeService.editIngredient(email, fridgeIngredientEditDto);
+				fridgeService.editIngredient(email, fridgeIngredientUpdateDto);
 
 		return ResponseEntity.ok(new ResponseDto<>(null, fridgeIngredientInfoDtoList));
 	}

--- a/src/main/java/team/rescue/fridge/controller/FridgeController.java
+++ b/src/main/java/team/rescue/fridge/controller/FridgeController.java
@@ -75,6 +75,7 @@ public class FridgeController {
 
 		String email = principalDetails.getUsername();
 
+
 		List<FridgeIngredientInfoDto> fridgeIngredientInfoDtoList = fridgeService.addIngredient(email,
 				fridgeIngredientCreateDtoList);
 		return ResponseEntity.ok(

--- a/src/main/java/team/rescue/fridge/controller/FridgeController.java
+++ b/src/main/java/team/rescue/fridge/controller/FridgeController.java
@@ -84,14 +84,14 @@ public class FridgeController {
 
 	@PutMapping("/ingredients")
 	@PreAuthorize("hasAuthority('USER')")
-	public ResponseEntity<ResponseDto<List<FridgeIngredientInfoDto>>> editIngredient(
+	public ResponseEntity<ResponseDto<List<FridgeIngredientInfoDto>>> updateIngredient(
 			@RequestBody FridgeIngredientUpdateDto fridgeIngredientUpdateDto,
 			@AuthenticationPrincipal PrincipalDetails principalDetails
 	) {
 
 		String email = principalDetails.getUsername();
 		List<FridgeIngredientInfoDto> fridgeIngredientInfoDtoList =
-				fridgeService.editIngredient(email, fridgeIngredientUpdateDto);
+				fridgeService.modifyIngredient(email, fridgeIngredientUpdateDto);
 
 		return ResponseEntity.ok(new ResponseDto<>(null, fridgeIngredientInfoDtoList));
 	}

--- a/src/main/java/team/rescue/fridge/controller/FridgeController.java
+++ b/src/main/java/team/rescue/fridge/controller/FridgeController.java
@@ -4,10 +4,12 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,6 +18,7 @@ import team.rescue.common.dto.ResponseDto;
 import team.rescue.error.exception.ValidationException;
 import team.rescue.fridge.dto.FridgeDto;
 import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientCreateDto;
+import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientEditDto;
 import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientInfoDto;
 import team.rescue.fridge.service.FridgeService;
 import team.rescue.validator.ListValidator;
@@ -36,6 +39,7 @@ public class FridgeController {
 	 * @return 냉장고 및 포함된 재료 리스트
 	 */
 	@GetMapping
+	@PreAuthorize("hasAuthroize('USER')")
 	public ResponseEntity<ResponseDto<FridgeDto>> getFridge(
 			@AuthenticationPrincipal PrincipalDetails principalDetails) {
 
@@ -53,14 +57,13 @@ public class FridgeController {
 	 * @return 등록한 재료 목록
 	 */
 	@PostMapping("/ingredients")
+	@PreAuthorize("hasAuthority('USER')")
 	public ResponseEntity<ResponseDto<List<FridgeIngredientInfoDto>>> addIngredient(
 			@RequestBody List<FridgeIngredientCreateDto> fridgeIngredientCreateDtoList,
 			@AuthenticationPrincipal PrincipalDetails principalDetails,
 			Errors errors
 	) {
 
-		// List<Dto> 형태는 @Valid 어노테이션이 동작하지 않아서
-		// CustomValidator를 생성해서 유효성 검증을 해줘야 함.
 		listValidator.validate(fridgeIngredientCreateDtoList, errors);
 
 		if (errors.hasErrors()) {
@@ -71,10 +74,25 @@ public class FridgeController {
 		}
 
 		String email = principalDetails.getUsername();
+
+		List<FridgeIngredientInfoDto> fridgeIngredientInfoDtoList = fridgeService.addIngredient(email,
+				fridgeIngredientCreateDtoList);
+		return ResponseEntity.ok(
+				new ResponseDto<>(null, fridgeIngredientInfoDtoList));
+	}
+
+	@PutMapping("/ingredients")
+	@PreAuthorize("hasAuthority('USER')")
+	public ResponseEntity<ResponseDto<List<FridgeIngredientInfoDto>>> editIngredient(
+			@RequestBody FridgeIngredientEditDto fridgeIngredientEditDto,
+			@AuthenticationPrincipal PrincipalDetails principalDetails
+	) {
+
+		String email = principalDetails.getUsername();
 		List<FridgeIngredientInfoDto> fridgeIngredientInfoDtoList =
-				fridgeService.addIngredient(email, fridgeIngredientCreateDtoList);
+				fridgeService.editIngredient(email, fridgeIngredientEditDto);
 
 		return ResponseEntity.ok(new ResponseDto<>(null, fridgeIngredientInfoDtoList));
-
 	}
+
 }

--- a/src/main/java/team/rescue/fridge/dto/FridgeIngredientDto.java
+++ b/src/main/java/team/rescue/fridge/dto/FridgeIngredientDto.java
@@ -48,24 +48,8 @@ public class FridgeIngredientDto {
 	@Builder
 	public static class FridgeIngredientUpdateDto {
 
-		private Long id;
-		private String name;
-		private String memo;
-		private LocalDateTime expiredAt;
-	}
-
-	@Getter
-	@Setter
-	public static class FridgeIngredientDeleteDto {
-
-		private Long id;
-	}
-
-	@Getter
-	@Setter
-	@Builder
-	public static class FridgeIngredientEditDto {
 		private List<Long> deleteItem;
-		private List<FridgeIngredientUpdateDto> updateItem;
+		private List<FridgeIngredientInfoDto> updateItem;
 	}
+
 }

--- a/src/main/java/team/rescue/fridge/dto/FridgeIngredientDto.java
+++ b/src/main/java/team/rescue/fridge/dto/FridgeIngredientDto.java
@@ -2,6 +2,7 @@ package team.rescue.fridge.dto;
 
 import jakarta.validation.constraints.Future;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -42,4 +43,29 @@ public class FridgeIngredientDto {
 		}
 	}
 
+	@Getter
+	@Setter
+	@Builder
+	public static class FridgeIngredientUpdateDto {
+
+		private Long id;
+		private String name;
+		private String memo;
+		private LocalDateTime expiredAt;
+	}
+
+	@Getter
+	@Setter
+	public static class FridgeIngredientDeleteDto {
+
+		private Long id;
+	}
+
+	@Getter
+	@Setter
+	@Builder
+	public static class FridgeIngredientEditDto {
+		private List<Long> deleteItem;
+		private List<FridgeIngredientUpdateDto> updateItem;
+	}
 }

--- a/src/main/java/team/rescue/fridge/entity/FridgeIngredient.java
+++ b/src/main/java/team/rescue/fridge/entity/FridgeIngredient.java
@@ -41,4 +41,10 @@ public class FridgeIngredient {
 
 	@Column(name = "expired_at")
 	private LocalDateTime expiredAt;
+
+	public void updateFridgeIngredient(String name, String memo, LocalDateTime expiredAt) {
+		this.name = name;
+		this.memo = memo;
+		this.expiredAt = expiredAt;
+	}
 }

--- a/src/main/java/team/rescue/fridge/repository/FridgeIngredientRepository.java
+++ b/src/main/java/team/rescue/fridge/repository/FridgeIngredientRepository.java
@@ -10,7 +10,9 @@ import team.rescue.fridge.entity.FridgeIngredient;
 @Repository
 public interface FridgeIngredientRepository extends JpaRepository<FridgeIngredient, Long> {
 
-	boolean existsByNameAndMemoAndExpiredAt(String name, String memo, LocalDateTime expiredAt);
+	boolean existsByNameAndMemoAndExpiredAtAndFridge(String name, String memo,
+			LocalDateTime expiredAt, Fridge fridge);
 
 	List<FridgeIngredient> findByFridge(Fridge fridge);
+
 }

--- a/src/main/java/team/rescue/fridge/service/FridgeService.java
+++ b/src/main/java/team/rescue/fridge/service/FridgeService.java
@@ -115,7 +115,7 @@ public class FridgeService {
 	}
 
 	@Transactional
-	public List<FridgeIngredientInfoDto> editIngredient(String email,
+	public List<FridgeIngredientInfoDto> modifyIngredient(String email,
 			FridgeIngredientUpdateDto fridgeIngredientUpdateDto) {
 		Member member = memberRepository.findUserByEmail(email)
 				.orElseThrow(() -> new ServiceException(USER_NOT_FOUND));
@@ -127,7 +127,7 @@ public class FridgeService {
 		deleteIngredient(deleteItemList, fridge);
 
 		List<FridgeIngredientInfoDto> updateItemList = fridgeIngredientUpdateDto.getUpdateItem();
-		updateIngredient(updateItemList, fridge);
+		modifyIngredient(updateItemList, fridge);
 
 		List<FridgeIngredient> fridgeIngredientList = fridgeIngredientRepository.findByFridge(
 				fridge);
@@ -149,7 +149,7 @@ public class FridgeService {
 		}
 	}
 
-	private void updateIngredient(List<FridgeIngredientInfoDto> updateItemList, Fridge
+	private void modifyIngredient(List<FridgeIngredientInfoDto> updateItemList, Fridge
 			fridge) {
 		for (FridgeIngredientInfoDto fridgeIngredientInfoDto : updateItemList) {
 			FridgeIngredient fridgeIngredient = fridgeIngredientRepository.findById(

--- a/src/main/java/team/rescue/fridge/service/FridgeService.java
+++ b/src/main/java/team/rescue/fridge/service/FridgeService.java
@@ -1,16 +1,23 @@
 package team.rescue.fridge.service;
 
+import static team.rescue.error.type.AuthError.ACCESS_DENIED;
+import static team.rescue.error.type.ServiceError.FRIDGE_NOT_FOUND;
+import static team.rescue.error.type.ServiceError.INGREDIENT_NOT_FOUND;
+import static team.rescue.error.type.ServiceError.USER_NOT_FOUND;
+
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.rescue.error.exception.AuthException;
 import team.rescue.error.exception.ServiceException;
-import team.rescue.error.type.ServiceError;
 import team.rescue.fridge.dto.FridgeDto;
 import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientCreateDto;
+import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientEditDto;
 import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientInfoDto;
+import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientUpdateDto;
 import team.rescue.fridge.entity.Fridge;
 import team.rescue.fridge.entity.FridgeIngredient;
 import team.rescue.fridge.repository.FridgeIngredientRepository;
@@ -49,10 +56,10 @@ public class FridgeService {
 	public FridgeDto getFridgeIngredients(String email) {
 
 		Member member = memberRepository.findUserByEmail(email)
-				.orElseThrow(() -> new ServiceException(ServiceError.USER_NOT_FOUND));
+				.orElseThrow(() -> new ServiceException(USER_NOT_FOUND));
 
 		Fridge fridge = fridgeRepository.findByMember(member)
-				.orElseThrow(() -> new ServiceException(ServiceError.FRIDGE_NOT_FOUND));
+				.orElseThrow(() -> new ServiceException(FRIDGE_NOT_FOUND));
 
 		List<FridgeIngredient> fridgeIngredients = fridgeIngredientRepository.findByFridge(fridge);
 		List<FridgeIngredientInfoDto> fridgeIngredientInfoList = fridgeIngredients.stream()
@@ -80,16 +87,17 @@ public class FridgeService {
 	) {
 
 		Member member = memberRepository.findUserByEmail(email)
-				.orElseThrow(() -> new ServiceException(ServiceError.USER_NOT_FOUND));
+				.orElseThrow(() -> new ServiceException(USER_NOT_FOUND));
 
 		Fridge fridge = fridgeRepository.findByMember(member)
-				.orElseThrow(() -> new ServiceException(ServiceError.FRIDGE_NOT_FOUND));
+				.orElseThrow(() -> new ServiceException(FRIDGE_NOT_FOUND));
 
 		for (FridgeIngredientCreateDto fridgeIngredientCreateDto : fridgeIngredientCreateDtoList) {
-			if (!fridgeIngredientRepository.existsByNameAndMemoAndExpiredAt(
+			if (!fridgeIngredientRepository.existsByNameAndMemoAndExpiredAtAndFridge(
 					fridgeIngredientCreateDto.getName(),
 					fridgeIngredientCreateDto.getMemo(),
-					fridgeIngredientCreateDto.getExpiredAt())) {
+					fridgeIngredientCreateDto.getExpiredAt(),
+					fridge)) {
 
 				FridgeIngredient fridgeIngredient = FridgeIngredient.builder()
 						.fridge(fridge)
@@ -107,4 +115,58 @@ public class FridgeService {
 				.collect(Collectors.toList());
 	}
 
+	@Transactional
+	public List<FridgeIngredientInfoDto> editIngredient(String email,
+			FridgeIngredientEditDto fridgeIngredientEditDto) {
+		Member member = memberRepository.findUserByEmail(email)
+				.orElseThrow(() -> new ServiceException(USER_NOT_FOUND));
+
+		Fridge fridge = fridgeRepository.findByMember(member)
+				.orElseThrow(() -> new ServiceException(FRIDGE_NOT_FOUND));
+
+		List<Long> deleteItemList = fridgeIngredientEditDto.getDeleteItem();
+		deleteIngredient(deleteItemList, fridge);
+
+		List<FridgeIngredientUpdateDto> updateItemList = fridgeIngredientEditDto.getUpdateItem();
+		updateIngredient(updateItemList, fridge);
+
+		List<FridgeIngredient> fridgeIngredientList = fridgeIngredientRepository.findByFridge(
+				fridge);
+
+		return fridgeIngredientList.stream().map(FridgeIngredientInfoDto::of)
+				.collect(Collectors.toList());
+	}
+
+	private void deleteIngredient(List<Long> deleteItemList, Fridge fridge) {
+		for (Long id : deleteItemList) {
+			FridgeIngredient fridgeIngredient = fridgeIngredientRepository.findById(id)
+					.orElseThrow(() -> new ServiceException(INGREDIENT_NOT_FOUND));
+
+			if (fridgeIngredient.getFridge() != fridge) {
+				throw new AuthException(ACCESS_DENIED);
+			}
+
+			fridgeIngredientRepository.deleteById(id);
+		}
+	}
+
+	private void updateIngredient(List<FridgeIngredientUpdateDto> updateItemList, Fridge
+			fridge) {
+		for (FridgeIngredientUpdateDto fridgeIngredientUpdateDto : updateItemList) {
+			FridgeIngredient fridgeIngredient = fridgeIngredientRepository.findById(
+							fridgeIngredientUpdateDto.getId())
+					.orElseThrow(() -> new ServiceException(INGREDIENT_NOT_FOUND));
+
+			if (fridgeIngredient.getFridge() != fridge) {
+				throw new AuthException(ACCESS_DENIED);
+			}
+
+			fridgeIngredient.updateFridgeIngredient(
+					fridgeIngredientUpdateDto.getName(),
+					fridgeIngredientUpdateDto.getMemo(),
+					fridgeIngredientUpdateDto.getExpiredAt());
+
+			fridgeIngredientRepository.save(fridgeIngredient);
+		}
+	}
 }

--- a/src/main/java/team/rescue/fridge/service/FridgeService.java
+++ b/src/main/java/team/rescue/fridge/service/FridgeService.java
@@ -15,7 +15,6 @@ import team.rescue.error.exception.AuthException;
 import team.rescue.error.exception.ServiceException;
 import team.rescue.fridge.dto.FridgeDto;
 import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientCreateDto;
-import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientEditDto;
 import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientInfoDto;
 import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientUpdateDto;
 import team.rescue.fridge.entity.Fridge;
@@ -117,17 +116,17 @@ public class FridgeService {
 
 	@Transactional
 	public List<FridgeIngredientInfoDto> editIngredient(String email,
-			FridgeIngredientEditDto fridgeIngredientEditDto) {
+			FridgeIngredientUpdateDto fridgeIngredientUpdateDto) {
 		Member member = memberRepository.findUserByEmail(email)
 				.orElseThrow(() -> new ServiceException(USER_NOT_FOUND));
 
 		Fridge fridge = fridgeRepository.findByMember(member)
 				.orElseThrow(() -> new ServiceException(FRIDGE_NOT_FOUND));
 
-		List<Long> deleteItemList = fridgeIngredientEditDto.getDeleteItem();
+		List<Long> deleteItemList = fridgeIngredientUpdateDto.getDeleteItem();
 		deleteIngredient(deleteItemList, fridge);
 
-		List<FridgeIngredientUpdateDto> updateItemList = fridgeIngredientEditDto.getUpdateItem();
+		List<FridgeIngredientInfoDto> updateItemList = fridgeIngredientUpdateDto.getUpdateItem();
 		updateIngredient(updateItemList, fridge);
 
 		List<FridgeIngredient> fridgeIngredientList = fridgeIngredientRepository.findByFridge(
@@ -150,11 +149,11 @@ public class FridgeService {
 		}
 	}
 
-	private void updateIngredient(List<FridgeIngredientUpdateDto> updateItemList, Fridge
+	private void updateIngredient(List<FridgeIngredientInfoDto> updateItemList, Fridge
 			fridge) {
-		for (FridgeIngredientUpdateDto fridgeIngredientUpdateDto : updateItemList) {
+		for (FridgeIngredientInfoDto fridgeIngredientInfoDto : updateItemList) {
 			FridgeIngredient fridgeIngredient = fridgeIngredientRepository.findById(
-							fridgeIngredientUpdateDto.getId())
+							fridgeIngredientInfoDto.getId())
 					.orElseThrow(() -> new ServiceException(INGREDIENT_NOT_FOUND));
 
 			if (fridgeIngredient.getFridge() != fridge) {
@@ -162,9 +161,9 @@ public class FridgeService {
 			}
 
 			fridgeIngredient.updateFridgeIngredient(
-					fridgeIngredientUpdateDto.getName(),
-					fridgeIngredientUpdateDto.getMemo(),
-					fridgeIngredientUpdateDto.getExpiredAt());
+					fridgeIngredientInfoDto.getName(),
+					fridgeIngredientInfoDto.getMemo(),
+					fridgeIngredientInfoDto.getExpiredAt());
 
 			fridgeIngredientRepository.save(fridgeIngredient);
 		}


### PR DESCRIPTION
### 작업 내용 요약 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 변경점
<!---- 실제로 변경된 부분을 작성해주세요. -->
**AS-IS**


**TO-BE**
냉장고 재료 수정 및 삭제 기능 구현
deleteItem과 updateItem을 받아 일괄 처리 하도록 구현하였습니다.
@AuthenticationPrincipal을 통해 받아온 PrincipalDetails 객체가 null인 경우 로그인이 필요하다는 메시지를 주도록 했습니다.

### 비고
<!---- 리뷰어에게 하고 싶은 말이나, 참고해야할 부분이 있다면 알려주세요. -->
본인의 냉장고가 아닌 다른 사람의 냉장고의 재료를 접근하려고 할 때 ACCESS_DENIED 예외를 주었는데 더 구체적인 예외 메시지를 내리는 error를 생성해야 할까요?
Service 단에서 private 메소드로 delete와 update를 구분 짓기는 했는데 멘토님이 말씀하셨던 서비스 레이어에서의 기능 구분은 이걸 뜻하는게 맞을까요?
재료 등록 시에 이름, 메모, 유통기한이 전부 동일한 경우 추가되지 않도록 구현했었는데 다른 사람이 모두 동일하게 입력했을 때도 입력이 안되는 오류가 있어 수정했습니다. 
리뷰 이후 병합되면 얼른 테스트 코드 짜겠습니다.. 

### 테스트
<!---- 어떤 테스트를 진행했는지 적어주세요.-->

- [ ] 테스트 코드 작성
- [ ] API 테스트 
