### PR TITLE
회원 정보 조회 및 수정 기능 구현 #36

### DIFF
--- a/src/main/java/team/rescue/error/type/ServiceError.java
+++ b/src/main/java/team/rescue/error/type/ServiceError.java
@@ -23,6 +23,8 @@ public enum ServiceError {
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
 	EMAIL_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
 	EMAIL_CODE_MIS_MATCH(HttpStatus.BAD_REQUEST, "이메일 인증 코드가 일치하지 않습니다."),
+	USER_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+	PASSWORD_AND_PASSWORD_CHECK_MISMATCH(HttpStatus.BAD_REQUEST, "새 비밀번호와 비밀번호 확인 값이 일치하지 않습니다."),
 
 	// Recipe
 	RECIPE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 레시피를 찾을 수 없습니다."),

--- a/src/main/java/team/rescue/member/controller/MemberController.java
+++ b/src/main/java/team/rescue/member/controller/MemberController.java
@@ -32,10 +32,16 @@ public class MemberController {
 	) {
 		String email = principalDetails.getUsername();
 
+<<<<<<< HEAD
 
 		MemberDetailDto memberDetailDto = memberService.getMemberInfo(email);
 
 		return ResponseEntity.ok(new ResponseDto<>("회원 정보 조회에 성공하였습니다.", memberDetailDto));
+=======
+		MemberDetailDto memberDetailDto = memberService.getMemberInfo(email);
+
+		return ResponseEntity.ok(new ResponseDto<>(1, "회원 정보 조회에 성공하였습니다.", memberDetailDto));
+>>>>>>> de878d9 (fix: dto 네이밍 변경)
 	}
 
 	@PatchMapping("/info/nickname")
@@ -49,7 +55,11 @@ public class MemberController {
 		MemberDetailDto memberDetailDto = memberService.updateMemberNickname(email,
 				memberNicknameUpdateDto);
 
+<<<<<<< HEAD
 		return ResponseEntity.ok(new ResponseDto<>("회원 닉네임 변경에 성공하였습니다.", memberDetailDto));
+=======
+		return ResponseEntity.ok(new ResponseDto<>(1, "회원 닉네임 변경에 성공하였습니다.", memberDetailDto));
+>>>>>>> de878d9 (fix: dto 네이밍 변경)
 	}
 
 	@PatchMapping("/info/password")
@@ -63,6 +73,10 @@ public class MemberController {
 		MemberDetailDto memberDetailDto = memberService.updateMemberPassword(email,
 				memberPasswordUpdateDto);
 
+<<<<<<< HEAD
 		return ResponseEntity.ok(new ResponseDto<>("회원 비밀번호 변경에 성공하였습니다.", memberDetailDto));
+=======
+		return ResponseEntity.ok(new ResponseDto<>(1, "회원 비밀번호 변경에 성공하였습니다.", memberDetailDto));
+>>>>>>> de878d9 (fix: dto 네이밍 변경)
 	}
 }

--- a/src/main/java/team/rescue/member/controller/MemberController.java
+++ b/src/main/java/team/rescue/member/controller/MemberController.java
@@ -1,16 +1,20 @@
 package team.rescue.member.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import team.rescue.auth.user.PrincipalDetails;
 import team.rescue.common.dto.ResponseDto;
-import team.rescue.member.dto.MemberDto.MemberResDto;
+import team.rescue.member.dto.MemberDto;
+import team.rescue.member.dto.MemberDto.MemberDetailDto;
 import team.rescue.member.service.MemberService;
 
 @Slf4j
@@ -23,13 +27,41 @@ public class MemberController {
 
 	@GetMapping("/info")
 	@PreAuthorize("hasAuthority('USER')")
-	public ResponseEntity<ResponseDto<MemberResDto>> getMembersInfo(
+	public ResponseEntity<ResponseDto<MemberDetailDto>> getMembersInfo(
 			@AuthenticationPrincipal PrincipalDetails principalDetails
 	) {
 		String email = principalDetails.getUsername();
 
-		MemberResDto memberResDto = memberService.getMembersInfo(email);
+		MemberDetailDto memberDetailDto = memberService.getMembersInfo(email);
 
-		return ResponseEntity.ok(new ResponseDto<>(1, "회원 정보 조회에 성공하였습니다.", memberResDto));
+		return ResponseEntity.ok(new ResponseDto<>("회원 정보 조회에 성공하였습니다.", memberDetailDto));
+	}
+
+	@PatchMapping("/info/nickname")
+	@PreAuthorize("hasAuthority('USER')")
+	public ResponseEntity<ResponseDto<MemberDetailDto>> updateMemberNickname(
+			@RequestBody @Valid MemberDto.MemberNicknameUpdateDto memberNicknameUpdateDto,
+			@AuthenticationPrincipal PrincipalDetails principalDetails
+	) {
+		String email = principalDetails.getUsername();
+
+		MemberDetailDto memberDetailDto = memberService.updateMemberNickname(email,
+				memberNicknameUpdateDto);
+
+		return ResponseEntity.ok(new ResponseDto<>("회원 닉네임 변경에 성공하였습니다.", memberDetailDto));
+	}
+
+	@PatchMapping("/info/password")
+	@PreAuthorize("hasAuthority('USER')")
+	public ResponseEntity<ResponseDto<MemberDetailDto>> updateMemberPassword(
+			@RequestBody @Valid MemberDto.MemberPasswordUpdateDto memberPasswordUpdateDto,
+			@AuthenticationPrincipal PrincipalDetails principalDetails
+	) {
+		String email = principalDetails.getUsername();
+
+		MemberDetailDto memberDetailDto = memberService.updateMemberPassword(email,
+				memberPasswordUpdateDto);
+
+		return ResponseEntity.ok(new ResponseDto<>("회원 비밀번호 변경에 성공하였습니다.", memberDetailDto));
 	}
 }

--- a/src/main/java/team/rescue/member/controller/MemberController.java
+++ b/src/main/java/team/rescue/member/controller/MemberController.java
@@ -2,8 +2,16 @@ package team.rescue.member.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import team.rescue.auth.user.PrincipalDetails;
+import team.rescue.common.dto.ResponseDto;
+import team.rescue.member.dto.MemberDto.MemberResDto;
+import team.rescue.member.service.MemberService;
 
 @Slf4j
 @RestController
@@ -11,4 +19,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MemberController {
 
+	private final MemberService memberService;
+
+	@GetMapping("/info")
+	@PreAuthorize("hasAuthority('USER')")
+	public ResponseEntity<ResponseDto<MemberResDto>> getMembersInfo(
+			@AuthenticationPrincipal PrincipalDetails principalDetails
+	) {
+		String email = principalDetails.getUsername();
+
+		MemberResDto memberResDto = memberService.getMembersInfo(email);
+
+		return ResponseEntity.ok(new ResponseDto<>(1, "회원 정보 조회에 성공하였습니다.", memberResDto));
+	}
 }

--- a/src/main/java/team/rescue/member/controller/MemberController.java
+++ b/src/main/java/team/rescue/member/controller/MemberController.java
@@ -32,16 +32,9 @@ public class MemberController {
 	) {
 		String email = principalDetails.getUsername();
 
-<<<<<<< HEAD
-
 		MemberDetailDto memberDetailDto = memberService.getMemberInfo(email);
 
 		return ResponseEntity.ok(new ResponseDto<>("회원 정보 조회에 성공하였습니다.", memberDetailDto));
-=======
-		MemberDetailDto memberDetailDto = memberService.getMemberInfo(email);
-
-		return ResponseEntity.ok(new ResponseDto<>(1, "회원 정보 조회에 성공하였습니다.", memberDetailDto));
->>>>>>> de878d9 (fix: dto 네이밍 변경)
 	}
 
 	@PatchMapping("/info/nickname")
@@ -55,11 +48,7 @@ public class MemberController {
 		MemberDetailDto memberDetailDto = memberService.updateMemberNickname(email,
 				memberNicknameUpdateDto);
 
-<<<<<<< HEAD
 		return ResponseEntity.ok(new ResponseDto<>("회원 닉네임 변경에 성공하였습니다.", memberDetailDto));
-=======
-		return ResponseEntity.ok(new ResponseDto<>(1, "회원 닉네임 변경에 성공하였습니다.", memberDetailDto));
->>>>>>> de878d9 (fix: dto 네이밍 변경)
 	}
 
 	@PatchMapping("/info/password")
@@ -73,10 +62,6 @@ public class MemberController {
 		MemberDetailDto memberDetailDto = memberService.updateMemberPassword(email,
 				memberPasswordUpdateDto);
 
-<<<<<<< HEAD
 		return ResponseEntity.ok(new ResponseDto<>("회원 비밀번호 변경에 성공하였습니다.", memberDetailDto));
-=======
-		return ResponseEntity.ok(new ResponseDto<>(1, "회원 비밀번호 변경에 성공하였습니다.", memberDetailDto));
->>>>>>> de878d9 (fix: dto 네이밍 변경)
 	}
 }

--- a/src/main/java/team/rescue/member/controller/MemberController.java
+++ b/src/main/java/team/rescue/member/controller/MemberController.java
@@ -27,12 +27,13 @@ public class MemberController {
 
 	@GetMapping("/info")
 	@PreAuthorize("hasAuthority('USER')")
-	public ResponseEntity<ResponseDto<MemberDetailDto>> getMembersInfo(
+	public ResponseEntity<ResponseDto<MemberDetailDto>> getMemberInfo(
 			@AuthenticationPrincipal PrincipalDetails principalDetails
 	) {
 		String email = principalDetails.getUsername();
 
-		MemberDetailDto memberDetailDto = memberService.getMembersInfo(email);
+
+		MemberDetailDto memberDetailDto = memberService.getMemberInfo(email);
 
 		return ResponseEntity.ok(new ResponseDto<>("회원 정보 조회에 성공하였습니다.", memberDetailDto));
 	}

--- a/src/main/java/team/rescue/member/dto/MemberDto.java
+++ b/src/main/java/team/rescue/member/dto/MemberDto.java
@@ -1,5 +1,6 @@
 package team.rescue.member.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import team.rescue.auth.type.RoleType;
@@ -22,6 +23,26 @@ public class MemberDto {
 			memberInfo.setRole(member.getRole());
 
 			return memberInfo;
+		}
+	}
+
+	@Getter
+	@Setter
+	@Builder
+	public static class MemberResDto {
+
+		private Long id;
+		private String name;
+		private String nickname;
+		private String email;
+
+		public static MemberResDto of(Member member) {
+			return MemberResDto.builder()
+					.id(member.getId())
+					.name(member.getName())
+					.nickname(member.getNickname())
+					.email(member.getEmail())
+					.build();
 		}
 	}
 }

--- a/src/main/java/team/rescue/member/dto/MemberDto.java
+++ b/src/main/java/team/rescue/member/dto/MemberDto.java
@@ -3,8 +3,11 @@ package team.rescue.member.dto;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import team.rescue.auth.type.RoleType;
 import team.rescue.member.entity.Member;
@@ -49,16 +52,20 @@ public class MemberDto {
 		}
 	}
 
-	@Getter
-	@Setter
+	@Data
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
 	public static class MemberNicknameUpdateDto {
 
 		@Pattern(regexp = "^[a-zA-Z가-힣0-9]{2,15}", message = "한글, 영문 또는 숫자를 포함한 최소 2글자, 최대 15자의 닉네임을 입력해주세요.")
 		private String nickname;
 	}
 
-	@Getter
-	@Setter
+	@Data
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
 	public static class MemberPasswordUpdateDto {
 
 		@NotEmpty(message = "현재 비밀번호를 입력해주세요.")

--- a/src/main/java/team/rescue/member/dto/MemberDto.java
+++ b/src/main/java/team/rescue/member/dto/MemberDto.java
@@ -1,5 +1,8 @@
 package team.rescue.member.dto;
 
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -29,20 +32,43 @@ public class MemberDto {
 	@Getter
 	@Setter
 	@Builder
-	public static class MemberResDto {
+	public static class MemberDetailDto {
 
 		private Long id;
 		private String name;
 		private String nickname;
 		private String email;
 
-		public static MemberResDto of(Member member) {
-			return MemberResDto.builder()
+		public static MemberDetailDto of(Member member) {
+			return MemberDetailDto.builder()
 					.id(member.getId())
 					.name(member.getName())
 					.nickname(member.getNickname())
 					.email(member.getEmail())
 					.build();
 		}
+	}
+
+	@Getter
+	@Setter
+	public static class MemberNicknameUpdateDto {
+
+		@Pattern(regexp = "^[a-zA-Z가-힣0-9]{2,15}", message = "한글, 영문 또는 숫자를 포함한 최소 2글자, 최대 15자의 닉네임을 입력해주세요.")
+		private String nickname;
+	}
+
+	@Getter
+	@Setter
+	public static class MemberPasswordUpdateDto {
+
+		@NotEmpty(message = "현재 비밀번호를 입력해주세요.")
+		private String currentPassword;
+
+		@NotEmpty(message = "변경할 새 비밀번호를 입력해주세요.")
+		@Size(min = 8, max = 20, message = "최소 8글자, 최대 20글자의 비밀번호를 입력해주세요.")
+		private String newPassword;
+
+		@NotEmpty(message = "변경할 새 비밀번호를 한 번 더 입력해주세요.")
+		private String newPasswordCheck;
 	}
 }

--- a/src/main/java/team/rescue/member/entity/Member.java
+++ b/src/main/java/team/rescue/member/entity/Member.java
@@ -114,5 +114,13 @@ public class Member {
 	public void updateToken(String token) {
 		this.token = token;
 	}
+
+	public void updateNickname(String nickname) {
+		this.nickname = nickname;
+	}
+
+	public void updatePassword(String password) {
+		this.password = password;
+	}
 }
 

--- a/src/main/java/team/rescue/member/service/MemberService.java
+++ b/src/main/java/team/rescue/member/service/MemberService.java
@@ -26,7 +26,7 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 	private final PasswordEncoder passwordEncoder;
 
-	public MemberDetailDto getMembersInfo(String email) {
+	public MemberDetailDto getMemberInfo(String email) {
 		Member member = memberRepository.findUserByEmail(email)
 				.orElseThrow(() -> new ServiceException(USER_NOT_FOUND));
 

--- a/src/main/java/team/rescue/member/service/MemberService.java
+++ b/src/main/java/team/rescue/member/service/MemberService.java
@@ -4,6 +4,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.rescue.error.exception.UserException;
+import team.rescue.error.type.UserError;
+import team.rescue.member.dto.MemberDto.MemberResDto;
+import team.rescue.member.entity.Member;
+import team.rescue.member.repository.MemberRepository;
 
 @Slf4j
 @Service
@@ -11,4 +16,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberService {
 
+	private final MemberRepository memberRepository;
+
+	public MemberResDto getMembersInfo(String email) {
+		Member member = memberRepository.findUserByEmail(email)
+				.orElseThrow(() -> new UserException(UserError.USER_NOT_FOUND));
+
+		return MemberResDto.of(member);
+	}
 }

--- a/src/test/java/team/rescue/member/controller/MemberControllerTest.java
+++ b/src/test/java/team/rescue/member/controller/MemberControllerTest.java
@@ -21,9 +21,9 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import team.rescue.auth.type.RoleType;
-import team.rescue.member.dto.MemberDto.MemberNicknameUpdateReqDto;
-import team.rescue.member.dto.MemberDto.MemberPasswordUpdateReqDto;
-import team.rescue.member.dto.MemberDto.MemberResDto;
+import team.rescue.member.dto.MemberDto.MemberDetailDto;
+import team.rescue.member.dto.MemberDto.MemberNicknameUpdateDto;
+import team.rescue.member.dto.MemberDto.MemberPasswordUpdateDto;
 import team.rescue.member.repository.MemberRepository;
 import team.rescue.member.service.MemberService;
 import team.rescue.mock.MockMember;
@@ -55,7 +55,7 @@ class MemberControllerTest extends MockMember {
 	@WithMockMember(role = RoleType.USER)
 	void successGetMemberInfo() throws Exception {
 		// given
-		MemberResDto memberResDto = MemberResDto.builder()
+		MemberDetailDto memberDetailDto = MemberDetailDto.builder()
 				.id(1L)
 				.name("test")
 				.nickname("테스트")
@@ -63,7 +63,7 @@ class MemberControllerTest extends MockMember {
 				.build();
 
 		given(memberService.getMemberInfo("test@gmail.com"))
-				.willReturn(memberResDto);
+				.willReturn(memberDetailDto);
 
 		// when
 		// then
@@ -81,26 +81,26 @@ class MemberControllerTest extends MockMember {
 	@WithMockMember(role = RoleType.USER)
 	void successUpdateMemberNickname() throws Exception {
 		// given
-		MemberNicknameUpdateReqDto memberNicknameUpdateReqDto = MemberNicknameUpdateReqDto.builder()
+		MemberNicknameUpdateDto memberNicknameUpdateDto = MemberNicknameUpdateDto.builder()
 				.nickname("테스트2")
 				.build();
 
-		MemberResDto memberResDto = MemberResDto.builder()
+		MemberDetailDto memberDetailDto = MemberDetailDto.builder()
 				.id(1L)
 				.name("test")
 				.nickname("테스트2")
 				.email("test@gmail.com")
 				.build();
 
-		given(memberService.updateMemberNickname("test@gmail.com", memberNicknameUpdateReqDto))
-				.willReturn(memberResDto);
+		given(memberService.updateMemberNickname("test@gmail.com", memberNicknameUpdateDto))
+				.willReturn(memberDetailDto);
 
 		// when
 		// then
 		mockMvc.perform(patch("/api/members/info/nickname")
 						.contentType(APPLICATION_JSON)
 						.content(objectMapper.writeValueAsString(
-								memberNicknameUpdateReqDto
+								memberNicknameUpdateDto
 						)))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.data.id").value(1L))
@@ -115,14 +115,14 @@ class MemberControllerTest extends MockMember {
 	@WithMockMember(role = RoleType.USER)
 	void successUpdateMemberPassword() throws Exception {
 		// given
-		MemberPasswordUpdateReqDto memberPasswordUpdateReqDto = MemberPasswordUpdateReqDto.builder()
+		MemberPasswordUpdateDto memberPasswordUpdateDto = MemberPasswordUpdateDto.builder()
 				.currentPassword("asdfasdfasdf")
 				.newPassword("qwerqwerqwer")
 				.newPasswordCheck("qwerqwerqwer")
 				.build();
 
-		given(memberService.updateMemberPassword("test@gmail.com", memberPasswordUpdateReqDto))
-				.willReturn(MemberResDto.builder()
+		given(memberService.updateMemberPassword("test@gmail.com", memberPasswordUpdateDto))
+				.willReturn(MemberDetailDto.builder()
 						.id(1L)
 						.name("test")
 						.nickname("테스트")
@@ -134,7 +134,7 @@ class MemberControllerTest extends MockMember {
 		mockMvc.perform(patch("/api/members/info/password")
 						.contentType(APPLICATION_JSON)
 						.content(objectMapper.writeValueAsString(
-								memberPasswordUpdateReqDto
+								memberPasswordUpdateDto
 						)))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.message").value("회원 비밀번호 변경에 성공하였습니다."))

--- a/src/test/java/team/rescue/member/controller/MemberControllerTest.java
+++ b/src/test/java/team/rescue/member/controller/MemberControllerTest.java
@@ -1,0 +1,148 @@
+package team.rescue.member.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import team.rescue.auth.type.RoleType;
+import team.rescue.member.dto.MemberDto.MemberNicknameUpdateReqDto;
+import team.rescue.member.dto.MemberDto.MemberPasswordUpdateReqDto;
+import team.rescue.member.dto.MemberDto.MemberResDto;
+import team.rescue.member.repository.MemberRepository;
+import team.rescue.member.service.MemberService;
+import team.rescue.mock.MockMember;
+import team.rescue.mock.WithMockMember;
+
+@SpringBootTest(webEnvironment = WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles(profiles = "test")
+@Transactional
+class MemberControllerTest extends MockMember {
+
+	@MockBean
+	MemberService memberService;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@Autowired
+	PasswordEncoder passwordEncoder;
+
+	@Autowired
+	MemberRepository memberRepository;
+
+	@Test
+	@DisplayName("회원 정보 조회 성공")
+	@WithMockMember(role = RoleType.USER)
+	void successGetMemberInfo() throws Exception {
+		// given
+		MemberResDto memberResDto = MemberResDto.builder()
+				.id(1L)
+				.name("test")
+				.nickname("테스트")
+				.email("test@gmail.com")
+				.build();
+
+		given(memberService.getMemberInfo("test@gmail.com"))
+				.willReturn(memberResDto);
+
+		// when
+		// then
+		mockMvc.perform(get("/api/members/info"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.id").value(1L))
+				.andExpect(jsonPath("$.data.name").value("test"))
+				.andExpect(jsonPath("$.data.nickname").value("테스트"))
+				.andExpect(jsonPath("$.data.email").value("test@gmail.com"))
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("회원 닉네임 변경 성공")
+	@WithMockMember(role = RoleType.USER)
+	void successUpdateMemberNickname() throws Exception {
+		// given
+		MemberNicknameUpdateReqDto memberNicknameUpdateReqDto = MemberNicknameUpdateReqDto.builder()
+				.nickname("테스트2")
+				.build();
+
+		MemberResDto memberResDto = MemberResDto.builder()
+				.id(1L)
+				.name("test")
+				.nickname("테스트2")
+				.email("test@gmail.com")
+				.build();
+
+		given(memberService.updateMemberNickname("test@gmail.com", memberNicknameUpdateReqDto))
+				.willReturn(memberResDto);
+
+		// when
+		// then
+		mockMvc.perform(patch("/api/members/info/nickname")
+						.contentType(APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(
+								memberNicknameUpdateReqDto
+						)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.id").value(1L))
+				.andExpect(jsonPath("$.data.name").value("test"))
+				.andExpect(jsonPath("$.data.nickname").value("테스트2"))
+				.andExpect(jsonPath("$.data.email").value("test@gmail.com"))
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("회원 비밀번호 변경 성공")
+	@WithMockMember(role = RoleType.USER)
+	void successUpdateMemberPassword() throws Exception {
+		// given
+		MemberPasswordUpdateReqDto memberPasswordUpdateReqDto = MemberPasswordUpdateReqDto.builder()
+				.currentPassword("asdfasdfasdf")
+				.newPassword("qwerqwerqwer")
+				.newPasswordCheck("qwerqwerqwer")
+				.build();
+
+		given(memberService.updateMemberPassword("test@gmail.com", memberPasswordUpdateReqDto))
+				.willReturn(MemberResDto.builder()
+						.id(1L)
+						.name("test")
+						.nickname("테스트")
+						.email("test@gmail.com")
+						.build());
+
+		// when
+		// then
+		mockMvc.perform(patch("/api/members/info/password")
+						.contentType(APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(
+								memberPasswordUpdateReqDto
+						)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.message").value("회원 비밀번호 변경에 성공하였습니다."))
+				.andExpect(jsonPath("$.data.id").value(1L))
+				.andExpect(jsonPath("$.data.name").value("test"))
+				.andExpect(jsonPath("$.data.nickname").value("테스트"))
+				.andExpect(jsonPath("$.data.email").value("test@gmail.com"))
+				.andDo(print());
+
+	}
+}

--- a/src/test/java/team/rescue/member/service/MemberServiceTest.java
+++ b/src/test/java/team/rescue/member/service/MemberServiceTest.java
@@ -1,0 +1,259 @@
+package team.rescue.member.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static team.rescue.error.type.UserError.USER_NOT_FOUND;
+import static team.rescue.error.type.UserError.USER_PASSWORD_MISMATCH;
+
+import java.util.Objects;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import team.rescue.error.exception.ServiceException;
+import team.rescue.error.exception.UserException;
+import team.rescue.error.type.ServiceError;
+import team.rescue.member.dto.MemberDto.MemberNicknameUpdateReqDto;
+import team.rescue.member.dto.MemberDto.MemberPasswordUpdateReqDto;
+import team.rescue.member.dto.MemberDto.MemberResDto;
+import team.rescue.member.entity.Member;
+import team.rescue.member.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+	@Mock
+	MemberRepository memberRepository;
+
+	@Spy
+	PasswordEncoder passwordEncoder;
+
+	@InjectMocks
+	MemberService memberService;
+
+	@Test
+	@DisplayName("회원 정보 조회 성공")
+	void successGetMemberInfo() {
+		// given
+		Member member = Member.builder()
+				.id(1L)
+				.name("test")
+				.nickname("테스트")
+				.email("test@gmail.com")
+				.build();
+
+		given(memberRepository.findUserByEmail("test@gmail.com"))
+				.willReturn(Optional.of(member));
+
+		// when
+		MemberResDto memberResDto = memberService.getMemberInfo("test@gmail.com");
+
+		// then
+		assertEquals("test", memberResDto.getName());
+		assertEquals("테스트", memberResDto.getNickname());
+		assertEquals("test@gmail.com", memberResDto.getEmail());
+	}
+
+	@Test
+	@DisplayName("회원 정보 조회 실패 - 회원 정보 없음")
+	void failGetMemberInfo_UserNotFound() {
+		// given
+		given(memberRepository.findUserByEmail("test@gmail.com"))
+				.willReturn(Optional.empty());
+
+		// when
+		UserException userException = assertThrows(UserException.class,
+				() -> memberService.getMemberInfo("test@gmail.com"));
+
+		// then
+		assertEquals(USER_NOT_FOUND.getHttpStatus(), userException.getStatusCode());
+	}
+
+	@Test
+	@DisplayName("회원 닉네임 변경 성공")
+	void successUpdateMemberNickname() {
+		// given
+		Member member = Member.builder()
+				.id(1L)
+				.name("test")
+				.nickname("테스트")
+				.email("test@gmail.com")
+				.build();
+
+		given(memberRepository.findUserByEmail("test@gmail.com"))
+				.willReturn(Optional.of(member));
+
+		member.updateNickname("테스트2");
+
+		given(memberRepository.save(member))
+				.willReturn(Member.builder()
+						.id(1L)
+						.name("test")
+						.nickname("테스트2")
+						.email("test@gmail.com")
+						.build());
+
+		// when
+		MemberResDto memberResDto = memberService.updateMemberNickname("test@gmail.com",
+				MemberNicknameUpdateReqDto.builder()
+						.nickname("테스트2")
+						.build());
+
+		// then
+		assertEquals("test", memberResDto.getName());
+		assertEquals("테스트2", memberResDto.getNickname());
+		assertEquals("test@gmail.com", memberResDto.getEmail());
+	}
+
+	@Test
+	@DisplayName("회원 닉네임 변경 실패 - 사용자 정보 없음")
+	void failUpdateMemberNickname_UserNotFound() {
+		// given
+		given(memberRepository.findUserByEmail("test@gmail.com"))
+				.willReturn(Optional.empty());
+
+		// when
+		UserException userException = assertThrows(UserException.class,
+				() -> memberService.getMemberInfo("test@gmail.com"));
+
+		// then
+		assertEquals(USER_NOT_FOUND.getHttpStatus(), userException.getStatusCode());
+	}
+
+	@Test
+	@DisplayName("회원 비밀번호 변경 성공")
+	void successUpdateMemberPassword() {
+		// given
+		Member member = Member.builder()
+				.id(1L)
+				.name("test")
+				.nickname("테스트")
+				.email("test@gmail.com")
+				.password("1234567890")
+				.build();
+
+		MemberPasswordUpdateReqDto memberPasswordUpdateReqDto = MemberPasswordUpdateReqDto.builder()
+				.currentPassword("1234567890")
+				.newPassword("0987654321")
+				.newPasswordCheck("0987654321")
+				.build();
+
+		given(memberRepository.findUserByEmail("test@gmail.com"))
+				.willReturn(Optional.of(member));
+
+		given(passwordEncoder.matches(memberPasswordUpdateReqDto.getCurrentPassword(),
+				member.getPassword()))
+				.willReturn(true);
+
+		given(memberRepository.save(any()))
+				.willReturn(Member.builder()
+						.id(1L)
+						.name("test")
+						.nickname("테스트")
+						.email("test@gmail.com")
+						.password("0987654321")
+						.build());
+
+		// when
+		MemberResDto memberResDto = memberService.updateMemberPassword("test@gmail.com",
+				memberPasswordUpdateReqDto);
+
+		// then
+		assertEquals("test", memberResDto.getName());
+		assertEquals("테스트", memberResDto.getNickname());
+		assertEquals("test@gmail.com", memberResDto.getEmail());
+	}
+
+	@Test
+	@DisplayName("회원 비밀번호 변경 실패 - 사용자 정보 없음")
+	void failUpdateMemberPassword_UserNotFound() {
+		// given
+		given(memberRepository.findUserByEmail("test@gmail.com"))
+				.willReturn(Optional.empty());
+
+		// when
+		UserException userException = assertThrows(UserException.class,
+				() -> memberService.getMemberInfo("test@gmail.com"));
+
+		// then
+		assertEquals(USER_NOT_FOUND.getHttpStatus(), userException.getStatusCode());
+	}
+
+	@Test
+	@DisplayName("회원 비밀번호 변경 실패 - 현재 비밀번호 불일치")
+	void failUpdateMemberPassword_UserPasswordMismatch() {
+		// given
+		Member member = Member.builder()
+				.id(1L)
+				.name("test")
+				.nickname("테스트")
+				.email("test@gmail.com")
+				.password("1234567890")
+				.build();
+
+		MemberPasswordUpdateReqDto memberPasswordUpdateReqDto = MemberPasswordUpdateReqDto.builder()
+				.currentPassword("1234567890")
+				.newPassword("0987654321")
+				.newPasswordCheck("0987654321")
+				.build();
+
+		given(memberRepository.findUserByEmail("test@gmail.com"))
+				.willReturn(Optional.of(member));
+
+		given(passwordEncoder.matches(memberPasswordUpdateReqDto.getCurrentPassword(),
+				member.getPassword()))
+				.willReturn(false);
+
+		// when
+		UserException userException = assertThrows(UserException.class,
+				() -> memberService.updateMemberPassword("test@gmail.com", memberPasswordUpdateReqDto));
+
+		// then
+		assertEquals(USER_PASSWORD_MISMATCH.getHttpStatus(), userException.getStatusCode());
+	}
+
+	@Test
+	@DisplayName("회원 비밀번호 변경 실패 - 새 비밀번호와 비밀번호 확인 불일치")
+	void failUpdateMemberPassword_PasswordAndPasswordCheckMismatch() {
+		// given
+		Member member = Member.builder()
+				.id(1L)
+				.name("test")
+				.nickname("테스트")
+				.email("test@gmail.com")
+				.password("1234567890")
+				.build();
+
+		MemberPasswordUpdateReqDto memberPasswordUpdateReqDto = MemberPasswordUpdateReqDto.builder()
+				.currentPassword("1234567890")
+				.newPassword("0987654321")
+				.newPasswordCheck("123124124")
+				.build();
+
+		// when
+		ServiceException serviceException = assertThrows(ServiceException.class,
+				() -> passwordAndPasswordCheckMismatch(memberPasswordUpdateReqDto));
+
+		// then
+		assertEquals(ServiceError.PASSWORD_AND_PASSWORD_CHECK_MISMATCH.getHttpStatus(),
+				serviceException.getStatusCode());
+		verify(memberRepository, never()).save(any());
+	}
+
+	private void passwordAndPasswordCheckMismatch(
+			MemberPasswordUpdateReqDto memberPasswordUpdateReqDto) {
+		if (!Objects.equals(memberPasswordUpdateReqDto.getNewPassword(),
+				memberPasswordUpdateReqDto.getNewPasswordCheck())) {
+			throw new ServiceException(ServiceError.PASSWORD_AND_PASSWORD_CHECK_MISMATCH);
+		}
+	}
+}

--- a/src/test/java/team/rescue/member/service/MemberServiceTest.java
+++ b/src/test/java/team/rescue/member/service/MemberServiceTest.java
@@ -6,8 +6,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static team.rescue.error.type.UserError.USER_NOT_FOUND;
-import static team.rescue.error.type.UserError.USER_PASSWORD_MISMATCH;
+import static team.rescue.error.type.ServiceError.PASSWORD_AND_PASSWORD_CHECK_MISMATCH;
+import static team.rescue.error.type.ServiceError.USER_NOT_FOUND;
+import static team.rescue.error.type.ServiceError.USER_PASSWORD_MISMATCH;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -20,11 +21,9 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import team.rescue.error.exception.ServiceException;
-import team.rescue.error.exception.UserException;
-import team.rescue.error.type.ServiceError;
-import team.rescue.member.dto.MemberDto.MemberNicknameUpdateReqDto;
-import team.rescue.member.dto.MemberDto.MemberPasswordUpdateReqDto;
-import team.rescue.member.dto.MemberDto.MemberResDto;
+import team.rescue.member.dto.MemberDto.MemberDetailDto;
+import team.rescue.member.dto.MemberDto.MemberNicknameUpdateDto;
+import team.rescue.member.dto.MemberDto.MemberPasswordUpdateDto;
 import team.rescue.member.entity.Member;
 import team.rescue.member.repository.MemberRepository;
 
@@ -55,12 +54,12 @@ class MemberServiceTest {
 				.willReturn(Optional.of(member));
 
 		// when
-		MemberResDto memberResDto = memberService.getMemberInfo("test@gmail.com");
+		MemberDetailDto memberDetailDto = memberService.getMemberInfo("test@gmail.com");
 
 		// then
-		assertEquals("test", memberResDto.getName());
-		assertEquals("테스트", memberResDto.getNickname());
-		assertEquals("test@gmail.com", memberResDto.getEmail());
+		assertEquals("test", memberDetailDto.getName());
+		assertEquals("테스트", memberDetailDto.getNickname());
+		assertEquals("test@gmail.com", memberDetailDto.getEmail());
 	}
 
 	@Test
@@ -71,11 +70,11 @@ class MemberServiceTest {
 				.willReturn(Optional.empty());
 
 		// when
-		UserException userException = assertThrows(UserException.class,
+		ServiceException serviceException = assertThrows(ServiceException.class,
 				() -> memberService.getMemberInfo("test@gmail.com"));
 
 		// then
-		assertEquals(USER_NOT_FOUND.getHttpStatus(), userException.getStatusCode());
+		assertEquals(USER_NOT_FOUND.getHttpStatus(), serviceException.getStatusCode());
 	}
 
 	@Test
@@ -103,15 +102,15 @@ class MemberServiceTest {
 						.build());
 
 		// when
-		MemberResDto memberResDto = memberService.updateMemberNickname("test@gmail.com",
-				MemberNicknameUpdateReqDto.builder()
+		MemberDetailDto memberDetailDto = memberService.updateMemberNickname("test@gmail.com",
+				MemberNicknameUpdateDto.builder()
 						.nickname("테스트2")
 						.build());
 
 		// then
-		assertEquals("test", memberResDto.getName());
-		assertEquals("테스트2", memberResDto.getNickname());
-		assertEquals("test@gmail.com", memberResDto.getEmail());
+		assertEquals("test", memberDetailDto.getName());
+		assertEquals("테스트2", memberDetailDto.getNickname());
+		assertEquals("test@gmail.com", memberDetailDto.getEmail());
 	}
 
 	@Test
@@ -122,11 +121,11 @@ class MemberServiceTest {
 				.willReturn(Optional.empty());
 
 		// when
-		UserException userException = assertThrows(UserException.class,
+		ServiceException serviceException = assertThrows(ServiceException.class,
 				() -> memberService.getMemberInfo("test@gmail.com"));
 
 		// then
-		assertEquals(USER_NOT_FOUND.getHttpStatus(), userException.getStatusCode());
+		assertEquals(USER_NOT_FOUND.getHttpStatus(), serviceException.getStatusCode());
 	}
 
 	@Test
@@ -141,7 +140,7 @@ class MemberServiceTest {
 				.password("1234567890")
 				.build();
 
-		MemberPasswordUpdateReqDto memberPasswordUpdateReqDto = MemberPasswordUpdateReqDto.builder()
+		MemberPasswordUpdateDto memberPasswordUpdateDto = MemberPasswordUpdateDto.builder()
 				.currentPassword("1234567890")
 				.newPassword("0987654321")
 				.newPasswordCheck("0987654321")
@@ -150,7 +149,7 @@ class MemberServiceTest {
 		given(memberRepository.findUserByEmail("test@gmail.com"))
 				.willReturn(Optional.of(member));
 
-		given(passwordEncoder.matches(memberPasswordUpdateReqDto.getCurrentPassword(),
+		given(passwordEncoder.matches(memberPasswordUpdateDto.getCurrentPassword(),
 				member.getPassword()))
 				.willReturn(true);
 
@@ -164,13 +163,13 @@ class MemberServiceTest {
 						.build());
 
 		// when
-		MemberResDto memberResDto = memberService.updateMemberPassword("test@gmail.com",
-				memberPasswordUpdateReqDto);
+		MemberDetailDto memberDetailDto = memberService.updateMemberPassword("test@gmail.com",
+				memberPasswordUpdateDto);
 
 		// then
-		assertEquals("test", memberResDto.getName());
-		assertEquals("테스트", memberResDto.getNickname());
-		assertEquals("test@gmail.com", memberResDto.getEmail());
+		assertEquals("test", memberDetailDto.getName());
+		assertEquals("테스트", memberDetailDto.getNickname());
+		assertEquals("test@gmail.com", memberDetailDto.getEmail());
 	}
 
 	@Test
@@ -181,11 +180,11 @@ class MemberServiceTest {
 				.willReturn(Optional.empty());
 
 		// when
-		UserException userException = assertThrows(UserException.class,
+		ServiceException serviceException = assertThrows(ServiceException.class,
 				() -> memberService.getMemberInfo("test@gmail.com"));
 
 		// then
-		assertEquals(USER_NOT_FOUND.getHttpStatus(), userException.getStatusCode());
+		assertEquals(USER_NOT_FOUND.getHttpStatus(), serviceException.getStatusCode());
 	}
 
 	@Test
@@ -200,7 +199,7 @@ class MemberServiceTest {
 				.password("1234567890")
 				.build();
 
-		MemberPasswordUpdateReqDto memberPasswordUpdateReqDto = MemberPasswordUpdateReqDto.builder()
+		MemberPasswordUpdateDto memberPasswordUpdateDto = MemberPasswordUpdateDto.builder()
 				.currentPassword("1234567890")
 				.newPassword("0987654321")
 				.newPasswordCheck("0987654321")
@@ -209,16 +208,16 @@ class MemberServiceTest {
 		given(memberRepository.findUserByEmail("test@gmail.com"))
 				.willReturn(Optional.of(member));
 
-		given(passwordEncoder.matches(memberPasswordUpdateReqDto.getCurrentPassword(),
+		given(passwordEncoder.matches(memberPasswordUpdateDto.getCurrentPassword(),
 				member.getPassword()))
 				.willReturn(false);
 
 		// when
-		UserException userException = assertThrows(UserException.class,
-				() -> memberService.updateMemberPassword("test@gmail.com", memberPasswordUpdateReqDto));
+		ServiceException serviceException = assertThrows(ServiceException.class,
+				() -> memberService.updateMemberPassword("test@gmail.com", memberPasswordUpdateDto));
 
 		// then
-		assertEquals(USER_PASSWORD_MISMATCH.getHttpStatus(), userException.getStatusCode());
+		assertEquals(USER_PASSWORD_MISMATCH.getHttpStatus(), serviceException.getStatusCode());
 	}
 
 	@Test
@@ -233,7 +232,7 @@ class MemberServiceTest {
 				.password("1234567890")
 				.build();
 
-		MemberPasswordUpdateReqDto memberPasswordUpdateReqDto = MemberPasswordUpdateReqDto.builder()
+		MemberPasswordUpdateDto memberPasswordUpdateDto = MemberPasswordUpdateDto.builder()
 				.currentPassword("1234567890")
 				.newPassword("0987654321")
 				.newPasswordCheck("123124124")
@@ -241,19 +240,19 @@ class MemberServiceTest {
 
 		// when
 		ServiceException serviceException = assertThrows(ServiceException.class,
-				() -> passwordAndPasswordCheckMismatch(memberPasswordUpdateReqDto));
+				() -> passwordAndPasswordCheckMismatch(memberPasswordUpdateDto));
 
 		// then
-		assertEquals(ServiceError.PASSWORD_AND_PASSWORD_CHECK_MISMATCH.getHttpStatus(),
+		assertEquals(PASSWORD_AND_PASSWORD_CHECK_MISMATCH.getHttpStatus(),
 				serviceException.getStatusCode());
 		verify(memberRepository, never()).save(any());
 	}
 
 	private void passwordAndPasswordCheckMismatch(
-			MemberPasswordUpdateReqDto memberPasswordUpdateReqDto) {
-		if (!Objects.equals(memberPasswordUpdateReqDto.getNewPassword(),
-				memberPasswordUpdateReqDto.getNewPasswordCheck())) {
-			throw new ServiceException(ServiceError.PASSWORD_AND_PASSWORD_CHECK_MISMATCH);
+			MemberPasswordUpdateDto memberPasswordUpdateDto) {
+		if (!Objects.equals(memberPasswordUpdateDto.getNewPassword(),
+				memberPasswordUpdateDto.getNewPasswordCheck())) {
+			throw new ServiceException(PASSWORD_AND_PASSWORD_CHECK_MISMATCH);
 		}
 	}
 }


### PR DESCRIPTION
### 작업 내용 요약 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 변경점
<!---- 실제로 변경된 부분을 작성해주세요. -->
**AS-IS**

**TO-BE**
회원 정보를 조회, 수정하는 기능을 구현했습니다.

### 비고
<!---- 리뷰어에게 하고 싶은 말이나, 참고해야할 부분이 있다면 알려주세요. -->
MemberControllerTest에서 updateNickname과 updatePassword를 테스트하는 과정에서 ResponseDto 응답 data 필드가 null이 들어오는 에러가 발생했습니다. 확인 해 보니 MemberNicknameUpdateReqDto, MemberPasswordUpdateReqDto에 적용되어있는 lombok 어노테이션이 @Getter와 @Setter 뿐이었는데 이를 @Data로 변경하니 data 필드에 값이 잘 들어옵니다. @Data 필드의 @EqualsAndHashCode가 이를 가능하게 해준다는거 같은데 정확한 이유를 모르겠네요...

MemberServiceTest에서 요청으로 받은 newPassword와 newPasswordCheck가 다른 경우 예외를 발생시키는 테스트를 구현하고 싶은데 여기서는 
```
given(memberRepository.findUserByEmail("test@gmail.com"))
				.willReturn(Optional.of(member));

given(passwordEncoder.matches(memberPasswordUpdateReqDto.getCurrentPassword(),
		member.getPassword()))
	.willReturn(false);
```
이 코드를 사용하면 쓸데없는 stub이라면서 오류를 내서 메서드를 따로 만들어서 구현해봤는데 이런식으로 작성하는게 맞는지 의문입니다.

### 테스트
<!---- 어떤 테스트를 진행했는지 적어주세요.-->

- [x] 테스트 코드 작성
- [x] API 테스트 
