### PR TITLE
레시피 관련 이미지 dto에 넣기#82

### DIFF
--- a/src/main/java/team/rescue/common/file/FileService.java
+++ b/src/main/java/team/rescue/common/file/FileService.java
@@ -39,6 +39,7 @@ public class FileService {
 
 		ObjectMetadata objectMetadata = new ObjectMetadata();
 		objectMetadata.setContentType(image.getContentType());
+		objectMetadata.setContentLength(image.getSize());
 
 		try {
 			PutObjectRequest putObjectRequest = new PutObjectRequest(

--- a/src/main/java/team/rescue/error/type/ServiceError.java
+++ b/src/main/java/team/rescue/error/type/ServiceError.java
@@ -29,6 +29,8 @@ public enum ServiceError {
 	// Recipe
 	RECIPE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 레시피를 찾을 수 없습니다."),
 
+	RECIPE_STEP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 레시피 스탭을 찾을 수 없습니다."),
+
 	// Fridge
 	FRIDGE_NOT_FOUND(HttpStatus.NOT_FOUND, "냉장고 정보가 없습니다."),
 

--- a/src/main/java/team/rescue/recipe/controller/RecipeController.java
+++ b/src/main/java/team/rescue/recipe/controller/RecipeController.java
@@ -5,16 +5,19 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import team.rescue.auth.user.PrincipalDetails;
 import team.rescue.common.dto.ResponseDto;
+import team.rescue.recipe.dto.RecipeDto.RecipeCreateDto;
 import team.rescue.recipe.dto.RecipeDto.RecipeResDto;
 import team.rescue.recipe.dto.RecipesDto.RecipesReqDto;
 import team.rescue.recipe.dto.RecipesDto.RecipesResDto;
@@ -46,26 +49,20 @@ public class RecipeController {
 	/**
 	 * 레시피 등록
 	 *
-	 * @param recipeImageFile   레시피 대표 이미지 파일
-	 * @param stepImageFileList 레시피 스텝 이미지 파일
-	 * @param recipesReqDto     등록할 레시피 데이터
+	 * @param recipeCreateDto     등록할 레시피 데이터
 	 * @param principalDetails  로그인 유저
 	 * @return 등록한 레시피 데이터
 	 */
 	@PutMapping("/recipes")
-	public ResponseEntity<ResponseDto<RecipesResDto>> addRecipe(
-			@RequestPart("file") MultipartFile recipeImageFile,
-			@RequestPart("stepFiles") List<MultipartFile> stepImageFileList,
-			@RequestPart("add") RecipesReqDto recipesReqDto,
+//	@PreAuthorize("hasAuthority('USER')")
+	public ResponseEntity<ResponseDto<RecipeCreateDto>> addRecipe(
+			RecipeCreateDto recipeCreateDto,
 			@AuthenticationPrincipal PrincipalDetails principalDetails) {
 
-		String email = principalDetails.getUsername();
-
-		RecipesResDto recipesResDto =
-				recipeService.addRecipe(recipeImageFile, stepImageFileList, recipesReqDto, email);
+		RecipeCreateDto createDto = recipeService.addRecipe(recipeCreateDto, principalDetails);
 
 		return new ResponseEntity<>(
-				new ResponseDto<>("레시피가 성공적으로 등록되었습니다.", recipesResDto),
+				new ResponseDto<>("레시피가 성공적으로 등록되었습니다.", createDto),
 				HttpStatus.CREATED
 		);
 	}

--- a/src/main/java/team/rescue/recipe/controller/RecipeController.java
+++ b/src/main/java/team/rescue/recipe/controller/RecipeController.java
@@ -1,26 +1,19 @@
 package team.rescue.recipe.controller;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 import team.rescue.auth.user.PrincipalDetails;
 import team.rescue.common.dto.ResponseDto;
 import team.rescue.recipe.dto.RecipeDto.RecipeCreateDto;
 import team.rescue.recipe.dto.RecipeDto.RecipeResDto;
-import team.rescue.recipe.dto.RecipesDto.RecipesReqDto;
-import team.rescue.recipe.dto.RecipesDto.RecipesResDto;
 import team.rescue.recipe.service.RecipeService;
 
 @Slf4j

--- a/src/main/java/team/rescue/recipe/dto/RecipeDto.java
+++ b/src/main/java/team/rescue/recipe/dto/RecipeDto.java
@@ -5,23 +5,32 @@ import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 import team.rescue.member.dto.MemberDto.MemberInfoDto;
+import team.rescue.recipe.dto.RecipeStepDto.RecipeStepCreateDto;
+import team.rescue.recipe.dto.RecipeStepDto.RecipeStepInfoDto;
 import team.rescue.recipe.entity.Recipe;
-import team.rescue.recipe.entity.RecipeIngredient;
-import team.rescue.recipe.entity.RecipeStep;
 
 public class RecipeDto {
 
 	// 레시피 등록(생성) 요청 DTO
 	@Getter
 	@Setter
+	@Builder
 	public static class RecipeCreateDto {
 
 		private String title;
 		private String summary;
-		private List<RecipeIngredient> recipeIngredients;
-		private List<RecipeStep> recipeSteps;
+		private MultipartFile recipeImageUrl;
+		private List<RecipeIngredientDto> recipeIngredients;
+		private List<RecipeStepCreateDto> recipeSteps;
 
+		public static RecipeCreateDto of(Recipe recipe) {
+			return RecipeCreateDto.builder()
+					.title(recipe.getTitle())
+					.summary(recipe.getSummary())
+					.build();
+		}
 	}
 
 	// 레시피 요약 조회 응답 DTO
@@ -77,7 +86,7 @@ public class RecipeDto {
 		private Integer bookmarkCount;
 		private LocalDateTime createdAt;
 		private List<RecipeIngredientDto> recipeIngredientList;
-		private List<RecipeStepDto> recipeStepList;
+		private List<RecipeStepInfoDto> recipeStepList;
 		private Long writerMemberId;
 		private String writerMemberNickName;
 

--- a/src/main/java/team/rescue/recipe/dto/RecipeIngredientDto.java
+++ b/src/main/java/team/rescue/recipe/dto/RecipeIngredientDto.java
@@ -1,10 +1,14 @@
 package team.rescue.recipe.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import team.rescue.recipe.entity.RecipeIngredient;
 
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 @Builder
 public class RecipeIngredientDto {
 

--- a/src/main/java/team/rescue/recipe/dto/RecipeStepDto.java
+++ b/src/main/java/team/rescue/recipe/dto/RecipeStepDto.java
@@ -2,24 +2,46 @@ package team.rescue.recipe.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 import team.rescue.recipe.entity.RecipeStep;
 
 @Getter
 @Builder
 public class RecipeStepDto {
 
-  private int stepNo;
-  private String stepImageUrl;
-  private String stepContents;
-  private String stepTip;
+  // 레시피 스탭 생성 DTO
+  @Getter
+  @Setter
+  public static class RecipeStepCreateDto {
 
-  public static RecipeStepDto of (RecipeStep recipeStep) {
-    return RecipeStepDto.builder()
-        .stepNo(recipeStep.getStepNo())
-        .stepImageUrl(recipeStep.getStepImageUrl())
-        .stepContents(recipeStep.getStepContents())
-        .stepTip(recipeStep.getStepTip())
-        .build();
+    private int stepNo;
+    private MultipartFile stepImageUrl;
+    private String stepContents;
+    private String stepTip;
+
   }
+
+  // 레시피 스탭 조회 DTO
+  @Getter
+  @Builder
+  public static class RecipeStepInfoDto {
+
+    private int stepNo;
+    private String  stepImageUrl;
+    private String stepContents;
+    private String stepTip;
+
+    public static RecipeStepInfoDto of(RecipeStep recipeStep) {
+      return RecipeStepInfoDto.builder()
+          .stepNo(recipeStep.getStepNo())
+          .stepImageUrl(recipeStep.getStepImageUrl())
+          .stepContents(recipeStep.getStepContents())
+          .stepTip(recipeStep.getStepTip())
+          .build();
+    }
+  }
+
+
 
 }

--- a/src/main/java/team/rescue/recipe/service/RecipeService.java
+++ b/src/main/java/team/rescue/recipe/service/RecipeService.java
@@ -14,7 +14,6 @@ import team.rescue.member.repository.MemberRepository;
 import team.rescue.recipe.dto.RecipeDto.RecipeCreateDto;
 import team.rescue.recipe.dto.RecipeDto.RecipeResDto;
 import team.rescue.recipe.dto.RecipeIngredientDto;
-import team.rescue.recipe.dto.RecipeStepDto;
 import team.rescue.recipe.dto.RecipeStepDto.RecipeStepCreateDto;
 import team.rescue.recipe.dto.RecipeStepDto.RecipeStepInfoDto;
 import team.rescue.recipe.entity.Recipe;

--- a/src/main/java/team/rescue/recipe/service/RecipeService.java
+++ b/src/main/java/team/rescue/recipe/service/RecipeService.java
@@ -5,17 +5,18 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
+import team.rescue.auth.user.PrincipalDetails;
 import team.rescue.common.file.FileService;
 import team.rescue.error.exception.ServiceException;
 import team.rescue.error.type.ServiceError;
 import team.rescue.member.entity.Member;
 import team.rescue.member.repository.MemberRepository;
+import team.rescue.recipe.dto.RecipeDto.RecipeCreateDto;
 import team.rescue.recipe.dto.RecipeDto.RecipeResDto;
 import team.rescue.recipe.dto.RecipeIngredientDto;
 import team.rescue.recipe.dto.RecipeStepDto;
-import team.rescue.recipe.dto.RecipesDto.RecipesReqDto;
-import team.rescue.recipe.dto.RecipesDto.RecipesResDto;
+import team.rescue.recipe.dto.RecipeStepDto.RecipeStepCreateDto;
+import team.rescue.recipe.dto.RecipeStepDto.RecipeStepInfoDto;
 import team.rescue.recipe.entity.Recipe;
 import team.rescue.recipe.entity.RecipeIngredient;
 import team.rescue.recipe.entity.RecipeStep;
@@ -62,8 +63,8 @@ public class RecipeService {
 
 		List<RecipeStep> recipeStepList =
 				recipeStepRepository.findByRecipe(recipe);
-		List<RecipeStepDto> recipeStepDtoList =
-				recipeStepList.stream().map(RecipeStepDto::of).toList();
+		List<RecipeStepInfoDto> recipeStepDtoList =
+				recipeStepList.stream().map(RecipeStepInfoDto::of).toList();
 
 		return RecipeResDto.builder()
 				.id(recipe.getId())
@@ -83,22 +84,23 @@ public class RecipeService {
 	}
 
 	@Transactional
-	public RecipesResDto addRecipe(MultipartFile recipeImageFile,
-			List<MultipartFile> stepImageFileList,
-			RecipesReqDto recipesReqDto, String email) {
+	public RecipeCreateDto addRecipe(
+			RecipeCreateDto recipeCreateDto, PrincipalDetails principalDetails) {
 
-		Member member = memberRepository.findUserByEmail(email)
+		String memberEmail = principalDetails.getMember().getEmail();
+
+		Member member = memberRepository.findUserByEmail(memberEmail)
 				.orElseThrow(() -> {
 					log.error("일치하는 사용자 정보 없음");
 					return new ServiceException(ServiceError.USER_NOT_FOUND);
 				});
 
 		// 레시피 대표 이미지 저장
-		String recipeImageFilePath = fileService.uploadImageToS3(recipeImageFile);
+		String recipeImageFilePath = fileService.uploadImageToS3(recipeCreateDto.getRecipeImageUrl());
 
 		Recipe recipe = Recipe.builder()
-				.title(recipesReqDto.getTitle())
-				.summary(recipesReqDto.getSummary())
+				.title(recipeCreateDto.getTitle())
+				.summary(recipeCreateDto.getSummary())
 				.recipeImageUrl(recipeImageFilePath)
 				.viewCount(0)
 				.reviewCount(0)
@@ -107,41 +109,47 @@ public class RecipeService {
 				.member(member) // 멤버 연결
 				.build();
 
+		log.debug("recipe : {}", recipe);
+
 		recipesRepository.save(recipe); // 먼저 Recipe 저장
 
-		for (RecipeIngredient recipeIngredient : recipesReqDto.getRecipeIngredientList()) {
+		// 레시피 재료 저장
+		for (RecipeIngredientDto recipeIngredientDto : recipeCreateDto.getRecipeIngredients()) {
 			RecipeIngredient ingredient = RecipeIngredient.builder()
-					.name(recipeIngredient.getName())
-					.amount(recipeIngredient.getAmount())
+					.name(recipeIngredientDto.getName())
+					.amount(recipeIngredientDto.getAmount())
 					.recipe(recipe) // 재료와 레시피 연결
 					.build();
+
+			log.debug("ingredient : {}", ingredient);
+
 			recipeIngredientRepository.save(ingredient);
 		}
 
-		for (int i = 0; i < recipesReqDto.getRecipeStepList().size(); i++) {
+		// 레시피 스탭들 저장
+		for (RecipeStepCreateDto recipeStepCreateDto : recipeCreateDto.getRecipeSteps()) {
 
-			RecipeStep recipeStep = recipesReqDto.getRecipeStepList().get(i);
-
-			String stepImageFilePath = null;
-			if (i < stepImageFileList.size()) {
-				MultipartFile stepImageFile = stepImageFileList.get(i);
-				if (!stepImageFile.isEmpty()) {
-					// 스텝 이미지 저장
-					stepImageFilePath = fileService.uploadImageToS3(stepImageFile);
-				}
+			String stepImageFilePath = "";	// 빈 문자열
+			if (!recipeStepCreateDto.getStepImageUrl().isEmpty()) {
+				// 스탭 이미지 저장
+				stepImageFilePath = fileService.uploadImageToS3(recipeStepCreateDto.getStepImageUrl());
 			}
 
 			RecipeStep step = RecipeStep.builder()
-					.stepNo(recipeStep.getStepNo())
+					.stepNo(recipeStepCreateDto.getStepNo())
 					.stepImageUrl(stepImageFilePath) // URL 설정
-					.stepContents(recipeStep.getStepContents())
-					.stepTip(recipeStep.getStepTip())
+					.stepContents(recipeStepCreateDto.getStepContents())
+					.stepTip(recipeStepCreateDto.getStepTip())
 					.recipe(recipe) // 레시피와 연결
 					.build();
+
+			log.debug("step : {}", step);
 
 			recipeStepRepository.save(step);
 		}
 
-		return new RecipesResDto(recipe);
+		log.debug("recipe : {}", recipe);
+
+		return RecipeCreateDto.of(recipe);
 	}
 }


### PR DESCRIPTION
### 작업 내용 요약 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 변경점
<!---- 실제로 변경된 부분을 작성해주세요. -->
**AS-IS**

레시피 등록시 대표이미지와, 스탭이미지가 requestPart로 되어있었습니다.
S3에 이미지를 등록시, 이미지 길이에대한 warning메세지가 나왔습니다.

**TO-BE**

이미지 부분을 모두 dto안에 넣어서 작동하게 구현했습니다.
FileService에 objectMetadata.setContentLength(image.getSize()); 를 추가해줬습니다.

### 비고
<!---- 리뷰어에게 하고 싶은 말이나, 참고해야할 부분이 있다면 알려주세요. -->

스탭 이미지가 없다면 빈 문자열("") 이 저장 되고, 있다면, 해당 이미지 주소값이 저장됩니다.

다음은 postman으로 실행한 테스트케이스 입니다.
![image](https://github.com/fridge-rescue/fridge-rescue-server/assets/36941592/18f6682e-eb73-46f2-81ea-01c735d943b8)


### 테스트
<!---- 어떤 테스트를 진행했는지 적어주세요.-->

- [ ] 테스트 코드 작성
- [ ] API 테스트 
