### PR TITLE
특정 레시피 북마크 기능 구현 #121

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     implementation 'net.coobird:thumbnailator:0.4.20'
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
 
+    // redis distributed lock
+    implementation 'org.redisson:redisson-spring-boot-starter:3.16.3'
+
     implementation 'com.auth0:java-jwt:4.4.0'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/team/rescue/aop/DistributedLock.java
+++ b/src/main/java/team/rescue/aop/DistributedLock.java
@@ -1,0 +1,17 @@
+package team.rescue.aop;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+public @interface DistributedLock {
+
+	String prefix();
+}

--- a/src/main/java/team/rescue/aop/LockAopAspect.java
+++ b/src/main/java/team/rescue/aop/LockAopAspect.java
@@ -1,0 +1,33 @@
+package team.rescue.aop;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@Component
+@Aspect
+@RequiredArgsConstructor
+@Slf4j
+public class LockAopAspect {
+
+	private final LockManager lockManager;
+
+	@Around("@annotation(DistributedLock) && args(recipeId, ..)")
+	public Object distributeLock(ProceedingJoinPoint pjp, Long recipeId) throws Throwable {
+
+		MethodSignature signature = (MethodSignature) pjp.getSignature();
+		DistributedLock lock = signature.getMethod().getAnnotation(DistributedLock.class);
+
+		lockManager.lock(lock.prefix(), String.valueOf(recipeId));
+
+		try {
+			return pjp.proceed();
+		} finally {
+			lockManager.unlock(lock.prefix(), String.valueOf(recipeId));
+		}
+	}
+}

--- a/src/main/java/team/rescue/aop/LockManager.java
+++ b/src/main/java/team/rescue/aop/LockManager.java
@@ -1,0 +1,48 @@
+package team.rescue.aop;
+
+import static team.rescue.error.type.ServiceError.LOCK_ACQUISITION_FAIL;
+import static team.rescue.error.type.ServiceError.LOCK_ALREADY_ASSIGNED;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+import team.rescue.error.exception.ServiceException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LockManager {
+
+	private final RedissonClient redissonClient;
+
+	public void lock(String prefix, String key) {
+		RLock lock = redissonClient.getLock(getLockKey(prefix, key));
+		log.info("Lock 획득 시도 {}", getLockKey(prefix, key));
+
+		try {
+			// 5초 시도, 10초안에 해제
+			boolean available = lock.tryLock(5, 10, TimeUnit.SECONDS);
+
+			if (!available) {
+				log.error("락 획득 실패!");
+				throw new ServiceException(LOCK_ALREADY_ASSIGNED);
+			}
+		} catch (Exception e) {
+			log.error("Redis lock failed", e);
+			throw new ServiceException(LOCK_ACQUISITION_FAIL);
+		}
+	}
+
+	public void unlock(String prefix, String key) {
+		log.info("{} lock 해제", getLockKey(prefix, key));
+		redissonClient.getLock(getLockKey(prefix, key)).unlock();
+	}
+
+	private String getLockKey(String prefix, String recipeId) {
+		return prefix + ":" + recipeId;
+	}
+
+}

--- a/src/main/java/team/rescue/config/RedisConfig.java
+++ b/src/main/java/team/rescue/config/RedisConfig.java
@@ -1,6 +1,9 @@
 package team.rescue.config;
 
 import lombok.RequiredArgsConstructor;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -37,5 +40,13 @@ public class RedisConfig {
 		redisTemplate.setConnectionFactory(redisConnectionFactory());
 
 		return redisTemplate;
+	}
+
+	@Bean
+	public RedissonClient redissonClient() {
+		Config config = new Config();
+		config.useSingleServer().setAddress("redis://" + host + ":" + port);
+
+		return Redisson.create(config);
 	}
 }

--- a/src/main/java/team/rescue/error/type/ServiceError.java
+++ b/src/main/java/team/rescue/error/type/ServiceError.java
@@ -41,7 +41,11 @@ public enum ServiceError {
 	INGREDIENT_NOT_FOUND(HttpStatus.NOT_FOUND, "재료 정보가 없습니다."),
 
 	// Notification
-	NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림 정보가 없습니다.");
+	NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림 정보가 없습니다."),
+
+	// Lock
+	LOCK_ACQUISITION_FAIL(HttpStatus.BAD_REQUEST, "잠시 후 다시 시도해주세요."),
+	LOCK_ALREADY_ASSIGNED(HttpStatus.BAD_REQUEST, "잠시 후 다시 시도해주세요.");
 
 	private final HttpStatus httpStatus;
 	private final String errorMessage;

--- a/src/main/java/team/rescue/recipe/controller/RecipeController.java
+++ b/src/main/java/team/rescue/recipe/controller/RecipeController.java
@@ -4,18 +4,21 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import team.rescue.auth.user.PrincipalDetails;
 import team.rescue.common.dto.ResponseDto;
+import team.rescue.recipe.dto.BookmarkDto.BookmarkInfoDto;
 import team.rescue.recipe.dto.RecipeDto.RecipeCreateDto;
 import team.rescue.recipe.dto.RecipeDto.RecipeDetailDto;
 import team.rescue.recipe.dto.RecipeDto.RecipeInfoDto;
@@ -99,5 +102,21 @@ public class RecipeController {
 				new ResponseDto<>("레시피가 성공적으로 삭제되었습니다.", recipeDeleteDto),
 				HttpStatus.OK
 		);
+	}
+
+	@PostMapping("/{recipeId}/bookmark")
+	@PreAuthorize("hasAuthority('USER')")
+	public ResponseEntity<ResponseDto<?>> bookmarkRecipe(
+			@PathVariable Long recipeId,
+			@AuthenticationPrincipal PrincipalDetails principalDetails
+	) {
+		BookmarkInfoDto bookmarkInfoDto = recipeService.bookmarkRecipe(recipeId,
+				principalDetails.getUsername());
+
+		if (bookmarkInfoDto.getIsBookmarked()) {
+			return ResponseEntity.ok(new ResponseDto<>("레시피를 북마크하였습니다.", bookmarkInfoDto));
+		} else {
+			return ResponseEntity.ok(new ResponseDto<>("레시피 북마크를 취소하였습니다.", bookmarkInfoDto));
+		}
 	}
 }

--- a/src/main/java/team/rescue/recipe/dto/BookmarkDto.java
+++ b/src/main/java/team/rescue/recipe/dto/BookmarkDto.java
@@ -1,0 +1,18 @@
+package team.rescue.recipe.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+public class BookmarkDto {
+
+	@Getter
+	@Setter
+	@Builder
+	public static class BookmarkInfoDto {
+
+		private Integer bookmarkCount;
+		private Boolean isBookmarked;
+	}
+
+}

--- a/src/main/java/team/rescue/recipe/entity/Recipe.java
+++ b/src/main/java/team/rescue/recipe/entity/Recipe.java
@@ -73,4 +73,12 @@ public class Recipe {
 		this.summary = summary;
 		this.recipeImageUrl = recipeImageUrl;
 	}
+
+	public void decreaseBookmarkCount() {
+		this.bookmarkCount--;
+	}
+
+	public void increaseBookmarkCount() {
+		this.bookmarkCount++;
+	}
 }

--- a/src/main/java/team/rescue/recipe/repository/BookmarkRepository.java
+++ b/src/main/java/team/rescue/recipe/repository/BookmarkRepository.java
@@ -1,14 +1,20 @@
 package team.rescue.recipe.repository;
 
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import team.rescue.member.entity.Member;
 import team.rescue.recipe.entity.Bookmark;
+import team.rescue.recipe.entity.Recipe;
 
 @Repository
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
 	Page<Bookmark> findByMember(Member member, Pageable pageable);
+
+	Optional<Bookmark> findByRecipeAndMember(Recipe recipe, Member member);
+
+	void deleteByRecipeAndMember(Recipe recipe, Member member);
 }

--- a/src/main/java/team/rescue/recipe/service/RecipeService.java
+++ b/src/main/java/team/rescue/recipe/service/RecipeService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.rescue.aop.DistributedLock;
 import team.rescue.auth.user.PrincipalDetails;
 import team.rescue.common.file.FileService;
 import team.rescue.error.exception.ServiceException;
@@ -14,6 +15,7 @@ import team.rescue.error.type.ServiceError;
 import team.rescue.member.dto.MemberDto.MemberInfoDto;
 import team.rescue.member.entity.Member;
 import team.rescue.member.repository.MemberRepository;
+import team.rescue.recipe.dto.BookmarkDto.BookmarkInfoDto;
 import team.rescue.recipe.dto.RecipeDto.RecipeCreateDto;
 import team.rescue.recipe.dto.RecipeDto.RecipeDetailDto;
 import team.rescue.recipe.dto.RecipeDto.RecipeInfoDto;
@@ -21,9 +23,11 @@ import team.rescue.recipe.dto.RecipeDto.RecipeUpdateDto;
 import team.rescue.recipe.dto.RecipeIngredientDto;
 import team.rescue.recipe.dto.RecipeStepDto.RecipeStepCreateDto;
 import team.rescue.recipe.dto.RecipeStepDto.RecipeStepInfoDto;
+import team.rescue.recipe.entity.Bookmark;
 import team.rescue.recipe.entity.Recipe;
 import team.rescue.recipe.entity.RecipeIngredient;
 import team.rescue.recipe.entity.RecipeStep;
+import team.rescue.recipe.repository.BookmarkRepository;
 import team.rescue.recipe.repository.RecipeIngredientRepository;
 import team.rescue.recipe.repository.RecipeStepRepository;
 import team.rescue.recipe.repository.RecipesRepository;
@@ -33,310 +37,349 @@ import team.rescue.recipe.repository.RecipesRepository;
 @RequiredArgsConstructor
 public class RecipeService {
 
-  private final RecipesRepository recipesRepository;
-  private final RecipeIngredientRepository recipeIngredientRepository;
-  private final RecipeStepRepository recipeStepRepository;
-  private final MemberRepository memberRepository;
-  private final FileService fileService;
+	private final RecipesRepository recipesRepository;
+	private final RecipeIngredientRepository recipeIngredientRepository;
+	private final RecipeStepRepository recipeStepRepository;
+	private final MemberRepository memberRepository;
+	private final FileService fileService;
+	private final BookmarkRepository bookmarkRepository;
 
-  public RecipeDetailDto getRecipe(Long id) {
+	public RecipeDetailDto getRecipe(Long id) {
 
-    Recipe recipe = recipesRepository.findById(id)
-        .orElseThrow(() -> {
-          log.error("레시피 없음");
-          return new ServiceException(ServiceError.RECIPE_NOT_FOUND);
-        });
-    log.debug("레시피 {}", recipe);
+		Recipe recipe = recipesRepository.findById(id)
+				.orElseThrow(() -> {
+					log.error("레시피 없음");
+					return new ServiceException(ServiceError.RECIPE_NOT_FOUND);
+				});
+		log.debug("레시피 {}", recipe);
 
-    Long memberId = recipe.getMember().getId();
-    log.debug("member Id {}", memberId);
+		Long memberId = recipe.getMember().getId();
+		log.debug("member Id {}", memberId);
 
-    Member member = memberRepository.findById(memberId)
-        .orElseThrow(() -> {
-          log.error("일치하는 사용자 정보 없음");
-          return new ServiceException(ServiceError.USER_NOT_FOUND);
-        });
+		Member member = memberRepository.findById(memberId)
+				.orElseThrow(() -> {
+					log.error("일치하는 사용자 정보 없음");
+					return new ServiceException(ServiceError.USER_NOT_FOUND);
+				});
 
-    MemberInfoDto memberInfoDto = MemberInfoDto.of(member);
+		MemberInfoDto memberInfoDto = MemberInfoDto.of(member);
 
-    List<RecipeIngredient> recipeIngredientList =
-        recipeIngredientRepository.findByRecipe(recipe);
-    List<RecipeIngredientDto> recipeIngredientDtoList =
-        recipeIngredientList.stream().map(RecipeIngredientDto::of).toList();
+		List<RecipeIngredient> recipeIngredientList =
+				recipeIngredientRepository.findByRecipe(recipe);
+		List<RecipeIngredientDto> recipeIngredientDtoList =
+				recipeIngredientList.stream().map(RecipeIngredientDto::of).toList();
 
-    List<RecipeStep> recipeStepList =
-        recipeStepRepository.findByRecipe(recipe);
-    List<RecipeStepInfoDto> recipeStepDtoList =
-        recipeStepList.stream().map(RecipeStepInfoDto::of).toList();
+		List<RecipeStep> recipeStepList =
+				recipeStepRepository.findByRecipe(recipe);
+		List<RecipeStepInfoDto> recipeStepDtoList =
+				recipeStepList.stream().map(RecipeStepInfoDto::of).toList();
 
-    return RecipeDetailDto.builder()
-        .id(recipe.getId())
-        .title(recipe.getTitle())
-        .summary(recipe.getSummary())
-        .recipeImageUrl(recipe.getRecipeImageUrl())
-        .viewCount(recipe.getViewCount())
-        .reviewCount(recipe.getReviewCount())
-        .reportCount(recipe.getReportCount())
-        .bookmarkCount(recipe.getBookmarkCount())
-        .createdAt(recipe.getCreatedAt())
-        .recipeIngredients(recipeIngredientDtoList)
-        .recipeSteps(recipeStepDtoList)
-        .author(memberInfoDto)
-        .build();
-  }
+		return RecipeDetailDto.builder()
+				.id(recipe.getId())
+				.title(recipe.getTitle())
+				.summary(recipe.getSummary())
+				.recipeImageUrl(recipe.getRecipeImageUrl())
+				.viewCount(recipe.getViewCount())
+				.reviewCount(recipe.getReviewCount())
+				.reportCount(recipe.getReportCount())
+				.bookmarkCount(recipe.getBookmarkCount())
+				.createdAt(recipe.getCreatedAt())
+				.recipeIngredients(recipeIngredientDtoList)
+				.recipeSteps(recipeStepDtoList)
+				.author(memberInfoDto)
+				.build();
+	}
 
-  @Transactional
-  public RecipeInfoDto addRecipe(RecipeCreateDto recipeCreateDto,
-      PrincipalDetails principalDetails) {
+	@Transactional
+	public RecipeInfoDto addRecipe(RecipeCreateDto recipeCreateDto,
+			PrincipalDetails principalDetails) {
 
-    String memberEmail = principalDetails.getMember().getEmail();
+		String memberEmail = principalDetails.getMember().getEmail();
 
-    Member member = memberRepository.findUserByEmail(memberEmail)
-        .orElseThrow(() -> {
-          log.error("일치하는 사용자 정보 없음");
-          return new ServiceException(ServiceError.USER_NOT_FOUND);
-        });
+		Member member = memberRepository.findUserByEmail(memberEmail)
+				.orElseThrow(() -> {
+					log.error("일치하는 사용자 정보 없음");
+					return new ServiceException(ServiceError.USER_NOT_FOUND);
+				});
 
-    // 레시피 대표 이미지 저장
-    String recipeImageFilePath = fileService.uploadImageToS3(recipeCreateDto.getRecipeImageUrl());
+		// 레시피 대표 이미지 저장
+		String recipeImageFilePath = fileService.uploadImageToS3(recipeCreateDto.getRecipeImageUrl());
 
-    Recipe recipe = Recipe.builder()
-        .title(recipeCreateDto.getTitle())
-        .summary(recipeCreateDto.getSummary())
-        .recipeImageUrl(recipeImageFilePath)
-        .viewCount(0)
-        .reviewCount(0)
-        .reportCount(0)
-        .bookmarkCount(0)
-        .member(member) // 멤버 연결
-        .build();
+		Recipe recipe = Recipe.builder()
+				.title(recipeCreateDto.getTitle())
+				.summary(recipeCreateDto.getSummary())
+				.recipeImageUrl(recipeImageFilePath)
+				.viewCount(0)
+				.reviewCount(0)
+				.reportCount(0)
+				.bookmarkCount(0)
+				.member(member) // 멤버 연결
+				.build();
 
-    recipesRepository.save(recipe); // 먼저 Recipe 저장
+		recipesRepository.save(recipe); // 먼저 Recipe 저장
 
-    for (RecipeIngredientDto recipeIngredientDto : recipeCreateDto.getRecipeIngredients()) {
-      RecipeIngredient ingredient = RecipeIngredient.builder()
-          .name(recipeIngredientDto.getName())
-          .amount(recipeIngredientDto.getAmount())
-          .recipe(recipe) // 재료와 레시피 연결
-          .build();
-      recipeIngredientRepository.save(ingredient);
-    }
+		for (RecipeIngredientDto recipeIngredientDto : recipeCreateDto.getRecipeIngredients()) {
+			RecipeIngredient ingredient = RecipeIngredient.builder()
+					.name(recipeIngredientDto.getName())
+					.amount(recipeIngredientDto.getAmount())
+					.recipe(recipe) // 재료와 레시피 연결
+					.build();
+			recipeIngredientRepository.save(ingredient);
+		}
 
-    // 레시피 스탭들 저장
-    for (RecipeStepCreateDto recipeStepCreateDto : recipeCreateDto.getRecipeSteps()) {
+		// 레시피 스탭들 저장
+		for (RecipeStepCreateDto recipeStepCreateDto : recipeCreateDto.getRecipeSteps()) {
 
-      String stepImageFilePath = "";  // 빈 문자열
-      if (!recipeStepCreateDto.getStepImageUrl().isEmpty()) {
-        // 스탭 이미지 저장
-        stepImageFilePath = fileService.uploadImageToS3(recipeStepCreateDto.getStepImageUrl());
-      }
+			String stepImageFilePath = "";  // 빈 문자열
+			if (!recipeStepCreateDto.getStepImageUrl().isEmpty()) {
+				// 스탭 이미지 저장
+				stepImageFilePath = fileService.uploadImageToS3(recipeStepCreateDto.getStepImageUrl());
+			}
 
-      RecipeStep step = RecipeStep.builder()
-          .stepNo(recipeStepCreateDto.getStepNo())
-          .stepImageUrl(stepImageFilePath) // URL 설정
-          .stepContents(recipeStepCreateDto.getStepContents())
-          .stepTip(recipeStepCreateDto.getStepTip())
-          .recipe(recipe) // 레시피와 연결
-          .build();
+			RecipeStep step = RecipeStep.builder()
+					.stepNo(recipeStepCreateDto.getStepNo())
+					.stepImageUrl(stepImageFilePath) // URL 설정
+					.stepContents(recipeStepCreateDto.getStepContents())
+					.stepTip(recipeStepCreateDto.getStepTip())
+					.recipe(recipe) // 레시피와 연결
+					.build();
 
-      recipeStepRepository.save(step);
-    }
+			recipeStepRepository.save(step);
+		}
 
-    return RecipeInfoDto.of(recipe);
-  }
+		return RecipeInfoDto.of(recipe);
+	}
 
 
-  @Transactional
-  public RecipeDetailDto updateRecipe(Long recipeId,
-      RecipeUpdateDto recipeUpdateDto,
-      PrincipalDetails principalDetails) {
+	@Transactional
+	public RecipeDetailDto updateRecipe(Long recipeId,
+			RecipeUpdateDto recipeUpdateDto,
+			PrincipalDetails principalDetails) {
 
-    Long memberId = principalDetails.getMember().getId();
+		Long memberId = principalDetails.getMember().getId();
 
-    Member member = memberRepository.findById(memberId)
-        .orElseThrow(() -> {
-          log.error("일치하는 사용자 정보 없음");
-          return new ServiceException(ServiceError.USER_NOT_FOUND);
-        });
+		Member member = memberRepository.findById(memberId)
+				.orElseThrow(() -> {
+					log.error("일치하는 사용자 정보 없음");
+					return new ServiceException(ServiceError.USER_NOT_FOUND);
+				});
 
-    Recipe recipe = recipesRepository.findById(recipeId)
-        .orElseThrow(() -> {
-          log.error("레시피 없음");
-          return new ServiceException(ServiceError.RECIPE_NOT_FOUND);
-        });
+		Recipe recipe = recipesRepository.findById(recipeId)
+				.orElseThrow(() -> {
+					log.error("레시피 없음");
+					return new ServiceException(ServiceError.RECIPE_NOT_FOUND);
+				});
 
-    if (!recipe.getMember().equals(member)) {
-      log.error("레시피를 작성한 회원이 아님");
-      throw new ServiceException(ServiceError.RECIPE_MEMBER_UNMATCHED);
-    }
+		if (!recipe.getMember().equals(member)) {
+			log.error("레시피를 작성한 회원이 아님");
+			throw new ServiceException(ServiceError.RECIPE_MEMBER_UNMATCHED);
+		}
 
-    // 레시피 대표 이미지 업데이트
-    fileService.deleteImages(recipe.getRecipeImageUrl());
-    String recipeImageFilePath = fileService.uploadImageToS3(recipeUpdateDto.getRecipeImageUrl());
+		// 레시피 대표 이미지 업데이트
+		fileService.deleteImages(recipe.getRecipeImageUrl());
+		String recipeImageFilePath = fileService.uploadImageToS3(recipeUpdateDto.getRecipeImageUrl());
 
-    recipe.update(
-            recipeUpdateDto.getTitle(),
-            recipeUpdateDto.getSummary(),
-            recipeImageFilePath
+		recipe.update(
+				recipeUpdateDto.getTitle(),
+				recipeUpdateDto.getSummary(),
+				recipeImageFilePath
+		);
+
+		recipesRepository.save(recipe);
+
+		// 레시피 ingredient 수정
+		List<RecipeIngredient> existingRecipeIngredientList =
+				recipeIngredientRepository.findByRecipe(recipe);
+		List<RecipeIngredientDto> updatedRecipeIngredients = new ArrayList<>();
+		for (RecipeIngredientDto recipeIngredientDto : recipeUpdateDto.getRecipeIngredients()) {
+
+			log.debug("레세피 재료 아이디: {}", recipeIngredientDto.getName());
+
+			// 기존 재료가 있는지 확인
+			Optional<RecipeIngredient> existingIngredient = existingRecipeIngredientList.stream()
+					.filter(ingredient -> ingredient.getName().equals(recipeIngredientDto.getName()))
+					.findFirst();
+
+			if (existingIngredient.isPresent()) {
+				// 기존 재료 수정
+				RecipeIngredient updatedIngredient = existingIngredient.get();
+
+				updatedIngredient.updateRecipeIngredient(
+						recipeIngredientDto.getName(), recipeIngredientDto.getAmount());
+
+				recipeIngredientRepository.save(updatedIngredient);
+
+				updatedRecipeIngredients.add(RecipeIngredientDto.of(updatedIngredient));
+			}
+			// 새로운 재료라면 추가
+			else {
+				RecipeIngredient newIngredient = RecipeIngredient.builder()
+						.name(recipeIngredientDto.getName())
+						.amount(recipeIngredientDto.getAmount())
+						.recipe(recipe)
+						.build();
+				recipeIngredientRepository.save(newIngredient);
+
+				updatedRecipeIngredients.add(RecipeIngredientDto.of(newIngredient));
+			}
+		}
+
+		// 재료 삭제 처리
+		List<RecipeIngredient> ingredientsToDelete = existingRecipeIngredientList.stream()
+				.filter(ingredient -> recipeUpdateDto.getRecipeIngredients().stream()
+						.noneMatch(dto -> dto.getName().equals(ingredient.getName()))).toList();
+
+		recipeIngredientRepository.deleteAll(ingredientsToDelete);
+
+		// 레시피 step 수정
+		List<RecipeStep> existingRecipeStepList = recipeStepRepository.findByRecipe(recipe);
+		List<RecipeStepInfoDto> updatedRecipeStep = new ArrayList<>();
+		for (RecipeStepCreateDto recipeStepCreateDto : recipeUpdateDto.getRecipeSteps()) {
+
+			Optional<RecipeStep> existingStep = existingRecipeStepList.stream()
+					.filter(ingredient -> ingredient.getStepNo() == (recipeStepCreateDto.getStepNo()))
+					.findFirst();
+
+			if (existingStep.isPresent()) {
+				// 기존 스텝의 이미지 삭제
+				fileService.deleteImages(existingStep.get().getStepImageUrl());
+
+				// 새 이미지 파일 경로 얻기
+				String newStepImageFilePath = fileService.uploadImageToS3(
+						recipeStepCreateDto.getStepImageUrl());
+
+				RecipeStep updatedStep = existingStep.get();
+
+				// 스텝 업데이트
+				updatedStep.updateRecipeStep(
+						recipeStepCreateDto.getStepNo(),
+						newStepImageFilePath,
+						recipeStepCreateDto.getStepContents(),
+						recipeStepCreateDto.getStepTip()
 				);
+				recipeStepRepository.save(updatedStep);
 
-    recipesRepository.save(recipe);
+				updatedRecipeStep.add(RecipeStepInfoDto.of(updatedStep));
+			} else {
+				String stepImageFilePath = "";  // 빈 문자열
+				if (!recipeStepCreateDto.getStepImageUrl().isEmpty()) {
+					// 스탭 이미지 저장
+					stepImageFilePath = fileService.uploadImageToS3(recipeStepCreateDto.getStepImageUrl());
+				}
 
-    // 레시피 ingredient 수정
-    List<RecipeIngredient> existingRecipeIngredientList =
-        recipeIngredientRepository.findByRecipe(recipe);
-    List<RecipeIngredientDto> updatedRecipeIngredients = new ArrayList<>();
-    for (RecipeIngredientDto recipeIngredientDto : recipeUpdateDto.getRecipeIngredients()) {
+				RecipeStep newStep = RecipeStep.builder()
+						.stepNo(recipeStepCreateDto.getStepNo())
+						.stepImageUrl(stepImageFilePath) // URL 설정
+						.stepContents(recipeStepCreateDto.getStepContents())
+						.stepTip(recipeStepCreateDto.getStepTip())
+						.recipe(recipe) // 레시피와 연결
+						.build();
 
-      log.debug("레세피 재료 아이디: {}", recipeIngredientDto.getName());
+				updatedRecipeStep.add(RecipeStepInfoDto.of(newStep));
 
-      // 기존 재료가 있는지 확인
-      Optional<RecipeIngredient> existingIngredient = existingRecipeIngredientList.stream()
-          .filter(ingredient -> ingredient.getName().equals(recipeIngredientDto.getName()))
-          .findFirst();
+				recipeStepRepository.save(newStep);
+			}
+		}
+		// 스탭 삭제 처리
+		List<RecipeStep> stepToDelete = existingRecipeStepList.stream()
+				.filter(ingredient -> recipeUpdateDto.getRecipeSteps().stream()
+						.noneMatch(dto -> dto.getStepNo() == (ingredient.getStepNo()))).toList();
 
-      if (existingIngredient.isPresent()) {
-        // 기존 재료 수정
-        RecipeIngredient updatedIngredient = existingIngredient.get();
+		recipeStepRepository.deleteAll(stepToDelete);
 
-        updatedIngredient.updateRecipeIngredient(
-            recipeIngredientDto.getName(), recipeIngredientDto.getAmount());
+		return RecipeDetailDto.builder()
+				.title(recipe.getTitle())
+				.summary(recipe.getSummary())
+				.recipeImageUrl(recipeImageFilePath)
+				.recipeIngredients(updatedRecipeIngredients)
+				.recipeSteps(updatedRecipeStep)
+				.build();
 
-        recipeIngredientRepository.save(updatedIngredient);
+	}
 
-        updatedRecipeIngredients.add(RecipeIngredientDto.of(updatedIngredient));
-      }
-      // 새로운 재료라면 추가
-      else {
-        RecipeIngredient newIngredient = RecipeIngredient.builder()
-            .name(recipeIngredientDto.getName())
-            .amount(recipeIngredientDto.getAmount())
-            .recipe(recipe)
-            .build();
-        recipeIngredientRepository.save(newIngredient);
+	@Transactional
+	public RecipeInfoDto deleteRecipe(Long recipeId,
+			PrincipalDetails principalDetails) {
 
-        updatedRecipeIngredients.add(RecipeIngredientDto.of(newIngredient));
-      }
-    }
+		Long memberId = principalDetails.getMember().getId();
 
-    // 재료 삭제 처리
-    List<RecipeIngredient> ingredientsToDelete = existingRecipeIngredientList.stream()
-        .filter(ingredient -> recipeUpdateDto.getRecipeIngredients().stream()
-            .noneMatch(dto -> dto.getName().equals(ingredient.getName()))).toList();
+		Member member = memberRepository.findById(memberId)
+				.orElseThrow(() -> {
+					log.error("일치하는 사용자 정보 없음");
+					return new ServiceException(ServiceError.USER_NOT_FOUND);
+				});
 
-    recipeIngredientRepository.deleteAll(ingredientsToDelete);
+		Recipe recipe = recipesRepository.findById(recipeId)
+				.orElseThrow(() -> {
+					log.error("레시피 없음");
+					return new ServiceException(ServiceError.RECIPE_NOT_FOUND);
+				});
 
-    // 레시피 step 수정
-    List<RecipeStep> existingRecipeStepList = recipeStepRepository.findByRecipe(recipe);
-    List<RecipeStepInfoDto> updatedRecipeStep = new ArrayList<>();
-    for (RecipeStepCreateDto recipeStepCreateDto : recipeUpdateDto.getRecipeSteps()) {
+		if (!recipe.getMember().equals(member)) {
+			log.error("레시피를 작성한 회원이 아님");
+			throw new ServiceException(ServiceError.RECIPE_MEMBER_UNMATCHED);
+		}
 
-      Optional<RecipeStep> existingStep = existingRecipeStepList.stream()
-          .filter(ingredient -> ingredient.getStepNo() == (recipeStepCreateDto.getStepNo()))
-          .findFirst();
+		// 레시피 대표 이미지 삭제
+		fileService.deleteImages(recipe.getRecipeImageUrl());
 
-      if (existingStep.isPresent()) {
-        // 기존 스텝의 이미지 삭제
-        fileService.deleteImages(existingStep.get().getStepImageUrl());
+		// 레시피 ingredient 삭제
+		List<RecipeIngredient> existingRecipeIngredientList =
+				recipeIngredientRepository.findByRecipe(recipe);
+		recipeIngredientRepository.deleteAll(existingRecipeIngredientList);
 
-        // 새 이미지 파일 경로 얻기
-        String newStepImageFilePath = fileService.uploadImageToS3(
-            recipeStepCreateDto.getStepImageUrl());
+		// 레시피 step 삭제
+		List<RecipeStep> existingRecipeStepList = recipeStepRepository.findByRecipe(recipe);
+		for (RecipeStep existingRecipeStep : existingRecipeStepList) {
 
-        RecipeStep updatedStep = existingStep.get();
+			// 이미지가 있는 스텝이면 s3에서 삭제
+			if (!(existingRecipeStep.getStepImageUrl() == null || existingRecipeStep.getStepImageUrl()
+					.isEmpty())) {
+				fileService.deleteImages(existingRecipeStep.getStepImageUrl());
+			}
+		}
+		recipeStepRepository.deleteAll(existingRecipeStepList);
 
-        // 스텝 업데이트
-        updatedStep.updateRecipeStep(
-            recipeStepCreateDto.getStepNo(),
-            newStepImageFilePath,
-            recipeStepCreateDto.getStepContents(),
-            recipeStepCreateDto.getStepTip()
-        );
-        recipeStepRepository.save(updatedStep);
+		recipesRepository.delete(recipe);
 
-        updatedRecipeStep.add(RecipeStepInfoDto.of(updatedStep));
-      } else {
-        String stepImageFilePath = "";  // 빈 문자열
-        if (!recipeStepCreateDto.getStepImageUrl().isEmpty()) {
-          // 스탭 이미지 저장
-          stepImageFilePath = fileService.uploadImageToS3(recipeStepCreateDto.getStepImageUrl());
-        }
+		return RecipeInfoDto.of(recipe);
+	}
 
-        RecipeStep newStep = RecipeStep.builder()
-            .stepNo(recipeStepCreateDto.getStepNo())
-            .stepImageUrl(stepImageFilePath) // URL 설정
-            .stepContents(recipeStepCreateDto.getStepContents())
-            .stepTip(recipeStepCreateDto.getStepTip())
-            .recipe(recipe) // 레시피와 연결
-            .build();
+	@Transactional
+	@DistributedLock(prefix = "bookmark_recipe")
+	public BookmarkInfoDto bookmarkRecipe(Long recipeId, String email) {
+		Member member = memberRepository.findUserByEmail(email)
+				.orElseThrow(() -> new ServiceException(ServiceError.USER_NOT_FOUND));
 
-        updatedRecipeStep.add(RecipeStepInfoDto.of(newStep));
+		Recipe recipe = recipesRepository.findById(recipeId)
+				.orElseThrow(() -> new ServiceException(ServiceError.RECIPE_NOT_FOUND));
 
-        recipeStepRepository.save(newStep);
-      }
-    }
-    // 스탭 삭제 처리
-    List<RecipeStep> stepToDelete = existingRecipeStepList.stream()
-        .filter(ingredient -> recipeUpdateDto.getRecipeSteps().stream()
-            .noneMatch(dto -> dto.getStepNo() == (ingredient.getStepNo()))).toList();
+		Optional<Bookmark> bookmarkOptional = bookmarkRepository.findByRecipeAndMember(recipe, member);
 
-    recipeStepRepository.deleteAll(stepToDelete);
+		// 이미 사용자가 해당 레시피를 북마크 한 경우
+		if (bookmarkOptional.isPresent()) {
+			bookmarkRepository.deleteByRecipeAndMember(recipe, member);
+			recipe.decreaseBookmarkCount();
+			recipesRepository.save(recipe);
 
-    return RecipeDetailDto.builder()
-        .title(recipe.getTitle())
-        .summary(recipe.getSummary())
-        .recipeImageUrl(recipeImageFilePath)
-        .recipeIngredients(updatedRecipeIngredients)
-        .recipeSteps(updatedRecipeStep)
-        .build();
+			return BookmarkInfoDto.builder()
+					.bookmarkCount(recipe.getBookmarkCount())
+					.isBookmarked(false)
+					.build();
+		} else { // 사용자가 해당 레시피를 북마크 하지 않은 경우
+			Bookmark bookmark = Bookmark.builder()
+					.recipe(recipe)
+					.member(member)
+					.build();
 
-  }
+			bookmarkRepository.save(bookmark);
+			recipe.increaseBookmarkCount();
+			recipesRepository.save(recipe);
 
-  @Transactional
-  public RecipeInfoDto deleteRecipe(Long recipeId,
-      PrincipalDetails principalDetails) {
-
-    Long memberId = principalDetails.getMember().getId();
-
-    Member member = memberRepository.findById(memberId)
-        .orElseThrow(() -> {
-          log.error("일치하는 사용자 정보 없음");
-          return new ServiceException(ServiceError.USER_NOT_FOUND);
-        });
-
-    Recipe recipe = recipesRepository.findById(recipeId)
-        .orElseThrow(() -> {
-          log.error("레시피 없음");
-          return new ServiceException(ServiceError.RECIPE_NOT_FOUND);
-        });
-
-    if (!recipe.getMember().equals(member)) {
-      log.error("레시피를 작성한 회원이 아님");
-      throw new ServiceException(ServiceError.RECIPE_MEMBER_UNMATCHED);
-    }
-
-    // 레시피 대표 이미지 삭제
-    fileService.deleteImages(recipe.getRecipeImageUrl());
-
-    // 레시피 ingredient 삭제
-    List<RecipeIngredient> existingRecipeIngredientList =
-        recipeIngredientRepository.findByRecipe(recipe);
-    recipeIngredientRepository.deleteAll(existingRecipeIngredientList);
-
-
-    // 레시피 step 삭제
-    List<RecipeStep> existingRecipeStepList = recipeStepRepository.findByRecipe(recipe);
-    for (RecipeStep existingRecipeStep : existingRecipeStepList) {
-
-      // 이미지가 있는 스텝이면 s3에서 삭제
-      if (!(existingRecipeStep.getStepImageUrl() == null || existingRecipeStep.getStepImageUrl().isEmpty())) {
-        fileService.deleteImages(existingRecipeStep.getStepImageUrl());
-      }
-    }
-    recipeStepRepository.deleteAll(existingRecipeStepList);
-
-    recipesRepository.delete(recipe);
-
-    return RecipeInfoDto.of(recipe);
-  }
+			return BookmarkInfoDto.builder()
+					.bookmarkCount(recipe.getBookmarkCount())
+					.isBookmarked(true)
+					.build();
+		}
+	}
 }

--- a/src/test/java/team/rescue/aop/LockAopAspectTest.java
+++ b/src/test/java/team/rescue/aop/LockAopAspectTest.java
@@ -1,0 +1,85 @@
+package team.rescue.aop;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.rescue.error.exception.ServiceException;
+import team.rescue.error.type.ServiceError;
+
+@ExtendWith(MockitoExtension.class)
+class LockAopAspectTest {
+
+	@Mock
+	LockManager lockManager;
+
+	@Mock
+	ProceedingJoinPoint proceedingJoinPoint;
+
+	@Mock
+	MethodSignature methodSignature;
+
+	@Mock
+	DistributedLock distributedLock;
+
+	@InjectMocks
+	LockAopAspect lockAopAspect;
+
+	@Test
+	@DisplayName("락 획득 및 해제 성공")
+	void lockAndUnlock() throws Throwable {
+		// given
+
+		given(proceedingJoinPoint.getSignature())
+				.willReturn(methodSignature);
+
+		given(methodSignature.getMethod())
+				.willReturn(getClass().getMethod("exampleMethod"));
+
+		lockAopAspect.distributeLock(proceedingJoinPoint, 123L);
+
+		// then
+		verify(lockManager, times(1)).lock(eq("recipe_bookmark"), anyString());
+		verify(proceedingJoinPoint, times(1)).proceed();
+		verify(lockManager, times(1)).unlock(eq("recipe_bookmark"), anyString());
+	}
+
+	@Test
+	@DisplayName("예외가 발생해도 락 획득 및 해제 성공")
+	void lockAndUnlock_evenIfException() throws Throwable {
+		// given
+		given(proceedingJoinPoint.getSignature())
+				.willReturn(methodSignature);
+
+		given(methodSignature.getMethod())
+				.willReturn(getClass().getMethod("exampleMethod"));
+
+		given(proceedingJoinPoint.proceed())
+				.willThrow(new ServiceException(ServiceError.LOCK_ACQUISITION_FAIL));
+
+		Assertions.assertThrows(ServiceException.class,
+				() -> lockAopAspect.distributeLock(proceedingJoinPoint, 123L));
+
+		// then
+		verify(lockManager, times(1)).lock(eq("recipe_bookmark"), anyString());
+		verify(proceedingJoinPoint, times(1)).proceed();
+		verify(lockManager, times(1)).unlock(eq("recipe_bookmark"), anyString());
+
+	}
+
+	@DistributedLock(prefix = "recipe_bookmark")
+	public String exampleMethod() {
+		return "result";
+	}
+}

--- a/src/test/java/team/rescue/recipe/controller/RecipeControllerTest.java
+++ b/src/test/java/team/rescue/recipe/controller/RecipeControllerTest.java
@@ -1,7 +1,7 @@
 package team.rescue.recipe.controller;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -29,12 +29,12 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import team.rescue.auth.type.ProviderType;
 import team.rescue.auth.type.RoleType;
-import team.rescue.auth.user.PrincipalDetails;
 import team.rescue.member.dto.MemberDto.MemberInfoDto;
 import team.rescue.member.entity.Member;
 import team.rescue.member.repository.MemberRepository;
 import team.rescue.mock.MockMember;
 import team.rescue.mock.WithMockMember;
+import team.rescue.recipe.dto.BookmarkDto.BookmarkInfoDto;
 import team.rescue.recipe.dto.RecipeDto.RecipeCreateDto;
 import team.rescue.recipe.dto.RecipeDto.RecipeDetailDto;
 import team.rescue.recipe.dto.RecipeIngredientDto;
@@ -48,196 +48,236 @@ import team.rescue.recipe.service.RecipeService;
 @Transactional
 class RecipeControllerTest extends MockMember {
 
-  @Autowired
-  MockMvc mockMvc;
+	@Autowired
+	MockMvc mockMvc;
 
-  @Autowired
-  ObjectMapper objectMapper;
+	@Autowired
+	ObjectMapper objectMapper;
 
-  @Autowired
-  private MemberRepository memberRepository;
+	@Autowired
+	private MemberRepository memberRepository;
 
-  @MockBean
-  RecipeService recipeService;
+	@MockBean
+	RecipeService recipeService;
 
-  private Member existMember;
+	private Member existMember;
 
-  @BeforeEach
-  public void setMember() {
-    this.existMember = memberRepository.save(
-        getNewMember("test", ProviderType.EMAIL, RoleType.USER)
-    );
-  }
+	@BeforeEach
+	public void setMember() {
+		this.existMember = memberRepository.save(
+				getNewMember("test", ProviderType.EMAIL, RoleType.USER)
+		);
+	}
 
-  List<RecipeIngredientDto> recipeIngredientList = new ArrayList<>();
+	List<RecipeIngredientDto> recipeIngredientList = new ArrayList<>();
 
-  @BeforeEach
-  public void setRecipeIngredientInfoDtoList() {
-    RecipeIngredientDto recipeIngredientDto1 = RecipeIngredientDto.builder()
-        .name("마늘")
-        .amount("3쫑")
-        .build();
-    RecipeIngredientDto recipeIngredientDto2 = RecipeIngredientDto.builder()
-        .name("양파")
-        .amount("2개")
-        .build();
-    RecipeIngredientDto recipeIngredientDto3 = RecipeIngredientDto.builder()
-        .name("쪽파")
-        .amount("2단")
-        .build();
+	@BeforeEach
+	public void setRecipeIngredientInfoDtoList() {
+		RecipeIngredientDto recipeIngredientDto1 = RecipeIngredientDto.builder()
+				.name("마늘")
+				.amount("3쫑")
+				.build();
+		RecipeIngredientDto recipeIngredientDto2 = RecipeIngredientDto.builder()
+				.name("양파")
+				.amount("2개")
+				.build();
+		RecipeIngredientDto recipeIngredientDto3 = RecipeIngredientDto.builder()
+				.name("쪽파")
+				.amount("2단")
+				.build();
 
-    recipeIngredientList.add(recipeIngredientDto1);
-    recipeIngredientList.add(recipeIngredientDto2);
-    recipeIngredientList.add(recipeIngredientDto3);
+		recipeIngredientList.add(recipeIngredientDto1);
+		recipeIngredientList.add(recipeIngredientDto2);
+		recipeIngredientList.add(recipeIngredientDto3);
 
-  }
+	}
 
-  List<RecipeStepInfoDto> recipeStepInfoDto = new ArrayList<>();
+	List<RecipeStepInfoDto> recipeStepInfoDto = new ArrayList<>();
 
-  @BeforeEach
-  public void setRecipeStepInfoDtoList() {
-    RecipeStepInfoDto recipeStepInfoDto1 = RecipeStepInfoDto.builder()
-        .stepNo(1)
-        .stepImageUrl("http://testRecipeSTEP1.com/image.jpg")
-        .stepContents("레시피 스탭1")
-        .stepTip("레시피 팁 1")
-        .build();
-    RecipeStepInfoDto recipeStepInfoDto2 = RecipeStepInfoDto.builder()
-        .stepNo(1)
-        .stepImageUrl("http://testRecipeSTEP2.com/image.jpg")
-        .stepContents("레시피 스탭2")
-        .stepTip("레시피 팁 2")
-        .build();
+	@BeforeEach
+	public void setRecipeStepInfoDtoList() {
+		RecipeStepInfoDto recipeStepInfoDto1 = RecipeStepInfoDto.builder()
+				.stepNo(1)
+				.stepImageUrl("http://testRecipeSTEP1.com/image.jpg")
+				.stepContents("레시피 스탭1")
+				.stepTip("레시피 팁 1")
+				.build();
+		RecipeStepInfoDto recipeStepInfoDto2 = RecipeStepInfoDto.builder()
+				.stepNo(1)
+				.stepImageUrl("http://testRecipeSTEP2.com/image.jpg")
+				.stepContents("레시피 스탭2")
+				.stepTip("레시피 팁 2")
+				.build();
 
-    recipeStepInfoDto.add(recipeStepInfoDto1);
-    recipeStepInfoDto.add(recipeStepInfoDto2);
-  }
+		recipeStepInfoDto.add(recipeStepInfoDto1);
+		recipeStepInfoDto.add(recipeStepInfoDto2);
+	}
 
 
-  List<RecipeStepCreateDto> recipeStepCreateList = new ArrayList<>();
+	List<RecipeStepCreateDto> recipeStepCreateList = new ArrayList<>();
 
-  @BeforeEach
-  public void setRecipeStepCreateDtoList() {
-    // 모의 이미지 파일 생성
-    MockMultipartFile mockImageFile1 = new MockMultipartFile(
-        "file",
-        "test1.jpg",
-        MediaType.IMAGE_JPEG_VALUE,
-        "recipe step test 1".getBytes()
-    );
-    MockMultipartFile mockImageFile2 = new MockMultipartFile(
-        "file",
-        "test2.jpg",
-        MediaType.IMAGE_JPEG_VALUE,
-        "recipe step test 2".getBytes()
-    );
+	@BeforeEach
+	public void setRecipeStepCreateDtoList() {
+		// 모의 이미지 파일 생성
+		MockMultipartFile mockImageFile1 = new MockMultipartFile(
+				"file",
+				"test1.jpg",
+				MediaType.IMAGE_JPEG_VALUE,
+				"recipe step test 1".getBytes()
+		);
+		MockMultipartFile mockImageFile2 = new MockMultipartFile(
+				"file",
+				"test2.jpg",
+				MediaType.IMAGE_JPEG_VALUE,
+				"recipe step test 2".getBytes()
+		);
 
-    RecipeStepCreateDto recipeStepDto1 = RecipeStepCreateDto.builder()
-        .stepNo(1)
-        .stepImageUrl(mockImageFile1)
-        .stepContents("레시피 스탭1")
-        .stepTip("레시피 팁 1")
-        .build();
+		RecipeStepCreateDto recipeStepDto1 = RecipeStepCreateDto.builder()
+				.stepNo(1)
+				.stepImageUrl(mockImageFile1)
+				.stepContents("레시피 스탭1")
+				.stepTip("레시피 팁 1")
+				.build();
 
-    RecipeStepCreateDto recipeStepDto2 = RecipeStepCreateDto.builder()
-        .stepNo(2)
-        .stepImageUrl(mockImageFile2)
-        .stepContents("레시피 스탭2")
-        .stepTip("레시피 팁 2")
-        .build();
+		RecipeStepCreateDto recipeStepDto2 = RecipeStepCreateDto.builder()
+				.stepNo(2)
+				.stepImageUrl(mockImageFile2)
+				.stepContents("레시피 스탭2")
+				.stepTip("레시피 팁 2")
+				.build();
 
-    recipeStepCreateList.add(recipeStepDto1);
-    recipeStepCreateList.add(recipeStepDto2);
+		recipeStepCreateList.add(recipeStepDto1);
+		recipeStepCreateList.add(recipeStepDto2);
 
-  }
+	}
 
-  @Test
-  @DisplayName("레시피 조회 성공")
-  @WithMockMember(role = RoleType.USER)
-  void successGetRecipe() throws Exception {
-    // given
-    Long recipeId = 1L;
+	@Test
+	@DisplayName("레시피 조회 성공")
+	@WithMockMember(role = RoleType.USER)
+	void successGetRecipe() throws Exception {
+		// given
+		Long recipeId = 1L;
 
-    MemberInfoDto mockAuthor = MemberInfoDto.of(existMember);
+		MemberInfoDto mockAuthor = MemberInfoDto.of(existMember);
 
-    given(recipeService.getRecipe(anyLong()))
-        .willReturn(RecipeDetailDto.builder()
-            .id(recipeId)
-            .title("레시피 타이틀 테스트")
-            .summary("레시피 요약 테스트")
-            .recipeImageUrl("http://testRecipe.com/image.jpg")
-            .viewCount(100)
-            .reviewCount(20)
-            .reportCount(0)
-            .bookmarkCount(10)
-            .createdAt(LocalDateTime.now())
-            .recipeIngredients(recipeIngredientList)
-            .recipeSteps(recipeStepInfoDto)
-            .author(mockAuthor)
-            .build());
+		given(recipeService.getRecipe(anyLong()))
+				.willReturn(RecipeDetailDto.builder()
+						.id(recipeId)
+						.title("레시피 타이틀 테스트")
+						.summary("레시피 요약 테스트")
+						.recipeImageUrl("http://testRecipe.com/image.jpg")
+						.viewCount(100)
+						.reviewCount(20)
+						.reportCount(0)
+						.bookmarkCount(10)
+						.createdAt(LocalDateTime.now())
+						.recipeIngredients(recipeIngredientList)
+						.recipeSteps(recipeStepInfoDto)
+						.author(mockAuthor)
+						.build());
 
-    // when
-    // then
-    mockMvc.perform(get("/api/recipes/" + recipeId))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.data.id").value(recipeId))
-        .andExpect(jsonPath("$.data.title").value("레시피 타이틀 테스트"))
-        .andExpect(jsonPath("$.data.summary").value("레시피 요약 테스트"))
-        .andExpect(jsonPath("$.data.recipeImageUrl").value("http://testRecipe.com/image.jpg"))
-        .andExpect(jsonPath("$.data.viewCount").value(100))
-        .andExpect(jsonPath("$.data.reviewCount").value(20))
-        .andExpect(jsonPath("$.data.reportCount").value(0))
-        .andExpect(jsonPath("$.data.bookmarkCount").value(10))
-        .andDo(print());
-  }
+		// when
+		// then
+		mockMvc.perform(get("/api/recipes/" + recipeId))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.id").value(recipeId))
+				.andExpect(jsonPath("$.data.title").value("레시피 타이틀 테스트"))
+				.andExpect(jsonPath("$.data.summary").value("레시피 요약 테스트"))
+				.andExpect(jsonPath("$.data.recipeImageUrl").value("http://testRecipe.com/image.jpg"))
+				.andExpect(jsonPath("$.data.viewCount").value(100))
+				.andExpect(jsonPath("$.data.reviewCount").value(20))
+				.andExpect(jsonPath("$.data.reportCount").value(0))
+				.andExpect(jsonPath("$.data.bookmarkCount").value(10))
+				.andDo(print());
+	}
 
-  @Test
-  @DisplayName("레시피 등록 성공")
-  @WithMockMember(role = RoleType.USER)
-  void successRecipe() throws Exception {
+	@Test
+	@DisplayName("레시피 등록 성공")
+	@WithMockMember(role = RoleType.USER)
+	void successRecipe() throws Exception {
 // given
-    MockMultipartFile mockRecipeImageFile = new MockMultipartFile(
-        "file",
-        "test.jpg",
-        MediaType.IMAGE_JPEG_VALUE,
-        "recipe Image test".getBytes()
-    );
+		MockMultipartFile mockRecipeImageFile = new MockMultipartFile(
+				"file",
+				"test.jpg",
+				MediaType.IMAGE_JPEG_VALUE,
+				"recipe Image test".getBytes()
+		);
 
-    RecipeCreateDto recipeCreateDto = RecipeCreateDto.builder()
-        .title("새로운 레시피")
-        .summary("레시피 요약")
-        .recipeImageUrl(mockRecipeImageFile)
-        .recipeIngredients(recipeIngredientList)
-        .recipeSteps(recipeStepCreateList)
-        .build();
+		RecipeCreateDto recipeCreateDto = RecipeCreateDto.builder()
+				.title("새로운 레시피")
+				.summary("레시피 요약")
+				.recipeImageUrl(mockRecipeImageFile)
+				.recipeIngredients(recipeIngredientList)
+				.recipeSteps(recipeStepCreateList)
+				.build();
 
-    given(recipeService.addRecipe(any(RecipeCreateDto.class), any(PrincipalDetails.class)))
-        .willReturn(recipeCreateDto);
+//    given(recipeService.addRecipe(any(RecipeCreateDto.class), any(PrincipalDetails.class)))
+//        .willReturn(recipeCreateDto);
 
-    objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+		objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
 
-    // when
-    // then
-    mockMvc.perform(
-            post("/api/recipes/recipes")
-                .contentType(MediaType.MULTIPART_FORM_DATA)
-                .content(objectMapper.writeValueAsString(
-                    recipeCreateDto
-                )))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.data.title").value("새로운 레시피"))
-        .andExpect(jsonPath("$.data.summary").value("레시피 요약"))
-        .andExpect(jsonPath("$.data.recipeIngredients[0].name").value("마늘"))
-        .andExpect(jsonPath("$.data.recipeIngredients[0].amount").value("3쫑"))
-        .andExpect(jsonPath("$.data.recipeIngredients[1].name").value("양파"))
-        .andExpect(jsonPath("$.data.recipeIngredients[1].amount").value("2개"))
-        .andExpect(jsonPath("$.data.recipeIngredients[2].name").value("쪽파"))
-        .andExpect(jsonPath("$.data.recipeIngredients[2].amount").value("2단"))
-        .andExpect(jsonPath("$.data.recipeSteps[0].stepContents").value("레시피 스탭1"))
-        .andExpect(jsonPath("$.data.recipeSteps[0].stepTip").value("레시피 팁 1"))
-        .andExpect(jsonPath("$.data.recipeSteps[1].stepContents").value("레시피 스탭2"))
-        .andExpect(jsonPath("$.data.recipeSteps[1].stepTip").value("레시피 팁 2"))
-        .andDo(print());
-  }
+		// when
+		// then
+		mockMvc.perform(
+						post("/api/recipes/recipes")
+								.contentType(MediaType.MULTIPART_FORM_DATA)
+								.content(objectMapper.writeValueAsString(
+										recipeCreateDto
+								)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.title").value("새로운 레시피"))
+				.andExpect(jsonPath("$.data.summary").value("레시피 요약"))
+				.andExpect(jsonPath("$.data.recipeIngredients[0].name").value("마늘"))
+				.andExpect(jsonPath("$.data.recipeIngredients[0].amount").value("3쫑"))
+				.andExpect(jsonPath("$.data.recipeIngredients[1].name").value("양파"))
+				.andExpect(jsonPath("$.data.recipeIngredients[1].amount").value("2개"))
+				.andExpect(jsonPath("$.data.recipeIngredients[2].name").value("쪽파"))
+				.andExpect(jsonPath("$.data.recipeIngredients[2].amount").value("2단"))
+				.andExpect(jsonPath("$.data.recipeSteps[0].stepContents").value("레시피 스탭1"))
+				.andExpect(jsonPath("$.data.recipeSteps[0].stepTip").value("레시피 팁 1"))
+				.andExpect(jsonPath("$.data.recipeSteps[1].stepContents").value("레시피 스탭2"))
+				.andExpect(jsonPath("$.data.recipeSteps[1].stepTip").value("레시피 팁 2"))
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("북마크 등록 성공")
+	@WithMockMember(role = RoleType.USER)
+	void successBookmarkRecipe() throws Exception {
+		// given
+		given(recipeService.bookmarkRecipe(anyLong(), anyString()))
+				.willReturn(BookmarkInfoDto.builder()
+						.bookmarkCount(1)
+						.isBookmarked(true)
+						.build());
+
+		// when
+		// then
+		mockMvc.perform(post("/api/recipes/1/bookmark"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.bookmarkCount").value(1))
+				.andExpect(jsonPath("$.data.isBookmarked").value(true))
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("북마크 취소 성공")
+	@WithMockMember(role = RoleType.USER)
+	void successCancelBookmarkRecipe() throws Exception {
+		// given
+		given(recipeService.bookmarkRecipe(anyLong(), anyString()))
+				.willReturn(BookmarkInfoDto.builder()
+						.bookmarkCount(0)
+						.isBookmarked(false)
+						.build());
+
+		// when
+		// then
+		mockMvc.perform(post("/api/recipes/1/bookmark"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.bookmarkCount").value(0))
+				.andExpect(jsonPath("$.data.isBookmarked").value(false))
+				.andDo(print());
+	}
 
 }


### PR DESCRIPTION
### 작업 내용 요약 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 변경점
<!---- 실제로 변경된 부분을 작성해주세요. -->
**AS-IS**

**TO-BE**
특정 레시피를 북마크 하는 기능을 구현했습니다.
이미 북마크 되어 있으면 북마크를 삭제하고, 북마크 되어 있지 않으면 북마크를 저장합니다.
이 과정에서 Recipe 테이블의 bookmarkCount를 업데이트 할때 동시성 이슈를 제어하기 위해 Redis 분산 락을 사용했습니다.

@DistributedLock 커스텀 어노테이션을 생성했고 해당 어노테이션을 락이 필요한 부분에 작성해주시면 됩니다.
prefix 필드를 필수로 명시해주셔야 하며 북마크의 경우 bookmark_recipe 형태로 작성했습니다.
DistributedLock 어노테이션이 붙어있는 메소드를 aop로 거를 때 recipeId가 맨 첫 번째 인자로 와야 하도록 구현했습니다.


### 비고
<!---- 리뷰어에게 하고 싶은 말이나, 참고해야할 부분이 있다면 알려주세요. -->
TODO : 후에 RecipeServiceTest에 bookmark 기능 테스트 코드 추가

락에 대해 빠삭하진 않아서 리뷰 부탁드립니다 ㅠ

### 테스트
<!---- 어떤 테스트를 진행했는지 적어주세요.-->

- [x] 테스트 코드 작성
- [x] API 테스트 
