### PR TITLE
요리 완료 기능 구현 #44

### DIFF
--- a/src/main/java/team/rescue/cook/controller/CookController.java
+++ b/src/main/java/team/rescue/cook/controller/CookController.java
@@ -2,8 +2,18 @@ package team.rescue.cook.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import team.rescue.auth.user.PrincipalDetails;
+import team.rescue.common.dto.ResponseDto;
+import team.rescue.cook.dto.CookDto.CookCreateDto;
+import team.rescue.cook.dto.CookDto.CookInfoDto;
+import team.rescue.cook.service.CookService;
 
 @Slf4j
 @RestController
@@ -11,4 +21,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class CookController {
 
+	private final CookService cookService;
+
+	@PostMapping
+	@PreAuthorize("hasAuthority('USER')")
+	public ResponseEntity<ResponseDto<CookInfoDto>> completeCook(
+			@RequestBody CookCreateDto cookCreateDto,
+			@AuthenticationPrincipal PrincipalDetails principalDetails
+	) {
+		CookInfoDto cookInfoDto = cookService.completeCook(cookCreateDto,
+				principalDetails.getUsername());
+
+		return ResponseEntity.ok(new ResponseDto<>("요리 완료 처리되었습니다.", cookInfoDto));
+	}
 }

--- a/src/main/java/team/rescue/cook/dto/CookDto.java
+++ b/src/main/java/team/rescue/cook/dto/CookDto.java
@@ -1,10 +1,12 @@
 package team.rescue.cook.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import team.rescue.cook.entity.Cook;
+import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientUseDto;
 import team.rescue.recipe.dto.RecipeDto.RecipeInfoDto;
 
 public class CookDto {
@@ -25,6 +27,15 @@ public class CookDto {
 					.recipeInfoDto(RecipeInfoDto.of(cook.getRecipe()))
 					.build();
 		}
+	}
+
+	@Getter
+	@Setter
+	@Builder
+	public static class CookCreateDto {
+
+		private Long recipeId;
+		private List<FridgeIngredientUseDto> fridgeIngredientUseDtoList;
 	}
 
 }

--- a/src/main/java/team/rescue/cook/service/CookService.java
+++ b/src/main/java/team/rescue/cook/service/CookService.java
@@ -1,6 +1,5 @@
 package team.rescue.cook.service;
 
-import static team.rescue.error.type.ServiceError.FRIDGE_NOT_FOUND;
 import static team.rescue.error.type.ServiceError.INGREDIENT_NOT_FOUND;
 import static team.rescue.error.type.ServiceError.RECIPE_NOT_FOUND;
 import static team.rescue.error.type.ServiceError.USER_NOT_FOUND;
@@ -16,7 +15,6 @@ import team.rescue.cook.entity.Cook;
 import team.rescue.cook.repository.CookRepository;
 import team.rescue.error.exception.ServiceException;
 import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientUseDto;
-import team.rescue.fridge.entity.Fridge;
 import team.rescue.fridge.entity.FridgeIngredient;
 import team.rescue.fridge.repository.FridgeIngredientRepository;
 import team.rescue.fridge.repository.FridgeRepository;
@@ -41,9 +39,6 @@ public class CookService {
 	public CookInfoDto completeCook(CookCreateDto cookCreateDto, String email) {
 		Member member = memberRepository.findUserByEmail(email)
 				.orElseThrow(() -> new ServiceException(USER_NOT_FOUND));
-
-		Fridge fridge = fridgeRepository.findByMember(member)
-				.orElseThrow(() -> new ServiceException(FRIDGE_NOT_FOUND));
 
 		List<FridgeIngredientUseDto> fridgeIngredientUseDtoList = cookCreateDto.getFridgeIngredientUseDtoList();
 

--- a/src/main/java/team/rescue/cook/service/CookService.java
+++ b/src/main/java/team/rescue/cook/service/CookService.java
@@ -1,9 +1,29 @@
 package team.rescue.cook.service;
 
+import static team.rescue.error.type.ServiceError.FRIDGE_NOT_FOUND;
+import static team.rescue.error.type.ServiceError.INGREDIENT_NOT_FOUND;
+import static team.rescue.error.type.ServiceError.RECIPE_NOT_FOUND;
+import static team.rescue.error.type.ServiceError.USER_NOT_FOUND;
+
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.rescue.cook.dto.CookDto.CookCreateDto;
+import team.rescue.cook.dto.CookDto.CookInfoDto;
+import team.rescue.cook.entity.Cook;
+import team.rescue.cook.repository.CookRepository;
+import team.rescue.error.exception.ServiceException;
+import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientUseDto;
+import team.rescue.fridge.entity.Fridge;
+import team.rescue.fridge.entity.FridgeIngredient;
+import team.rescue.fridge.repository.FridgeIngredientRepository;
+import team.rescue.fridge.repository.FridgeRepository;
+import team.rescue.member.entity.Member;
+import team.rescue.member.repository.MemberRepository;
+import team.rescue.recipe.entity.Recipe;
+import team.rescue.recipe.repository.RecipeRepository;
 
 @Slf4j
 @Service
@@ -11,4 +31,41 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CookService {
 
+	private final MemberRepository memberRepository;
+	private final RecipeRepository recipeRepository;
+	private final CookRepository cookRepository;
+	private final FridgeIngredientRepository fridgeIngredientRepository;
+	private final FridgeRepository fridgeRepository;
+
+	@Transactional
+	public CookInfoDto completeCook(CookCreateDto cookCreateDto, String email) {
+		Member member = memberRepository.findUserByEmail(email)
+				.orElseThrow(() -> new ServiceException(USER_NOT_FOUND));
+
+		Fridge fridge = fridgeRepository.findByMember(member)
+				.orElseThrow(() -> new ServiceException(FRIDGE_NOT_FOUND));
+
+		List<FridgeIngredientUseDto> fridgeIngredientUseDtoList = cookCreateDto.getFridgeIngredientUseDtoList();
+
+		for (FridgeIngredientUseDto fridgeIngredientUseDto : fridgeIngredientUseDtoList) {
+			FridgeIngredient fridgeIngredient = fridgeIngredientRepository.findById(
+							fridgeIngredientUseDto.getId())
+					.orElseThrow(() -> new ServiceException(INGREDIENT_NOT_FOUND));
+
+			fridgeIngredient.updateFridgeIngredient(fridgeIngredient.getName(),
+					fridgeIngredientUseDto.getMemo(), fridgeIngredient.getExpiredAt());
+
+			fridgeIngredientRepository.save(fridgeIngredient);
+		}
+
+		Recipe recipe = recipeRepository.findById(cookCreateDto.getRecipeId())
+				.orElseThrow(() -> new ServiceException(RECIPE_NOT_FOUND));
+
+		Cook savedCook = cookRepository.save(Cook.builder()
+				.recipe(recipe)
+				.member(member)
+				.build());
+
+		return CookInfoDto.of(savedCook);
+	}
 }

--- a/src/main/java/team/rescue/fridge/dto/FridgeIngredientDto.java
+++ b/src/main/java/team/rescue/fridge/dto/FridgeIngredientDto.java
@@ -56,4 +56,13 @@ public class FridgeIngredientDto {
 		private List<FridgeIngredientInfoDto> updateItem;
 	}
 
+	@Getter
+	@Setter
+	@Builder
+	public static class FridgeIngredientUseDto {
+
+		private Long id;
+		private String memo;
+	}
+
 }

--- a/src/test/java/team/rescue/cook/controller/CookControllerTest.java
+++ b/src/test/java/team/rescue/cook/controller/CookControllerTest.java
@@ -1,0 +1,88 @@
+package team.rescue.cook.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import team.rescue.auth.type.RoleType;
+import team.rescue.cook.dto.CookDto.CookCreateDto;
+import team.rescue.cook.dto.CookDto.CookInfoDto;
+import team.rescue.cook.service.CookService;
+import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientUseDto;
+import team.rescue.mock.WithMockMember;
+
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = WebEnvironment.MOCK)
+@ActiveProfiles(profiles = "test")
+@Transactional
+class CookControllerTest {
+
+	@MockBean
+	CookService cookService;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@Test
+	@DisplayName("요리 완료 성공")
+	@WithMockMember(role = RoleType.USER)
+	void successCompleteCook() throws Exception {
+		// given
+		given(cookService.completeCook(any(), anyString()))
+				.willReturn(CookInfoDto.builder()
+						.id(1L)
+						.createdAt(LocalDateTime.of(2024, 1, 12, 0, 0, 0))
+						.build());
+
+		FridgeIngredientUseDto fridgeIngredientUseDto1 = FridgeIngredientUseDto.builder()
+				.id(1L)
+				.memo("양파 2개")
+				.build();
+
+		FridgeIngredientUseDto fridgeIngredientUseDto2 = FridgeIngredientUseDto.builder()
+				.id(2L)
+				.memo("당근 반개")
+				.build();
+
+		List<FridgeIngredientUseDto> list = new ArrayList<>(
+				Arrays.asList(fridgeIngredientUseDto1, fridgeIngredientUseDto2));
+
+		// when
+		// then
+		mockMvc.perform(post("/api/cooks")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(
+								CookCreateDto.builder()
+										.recipeId(1L)
+										.fridgeIngredientUseDtoList(list)
+										.build()
+						)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.id").value(1L))
+				.andExpect(jsonPath("$.data.createdAt").value("2024-01-12T00:00:00"))
+				.andDo(print());
+	}
+}

--- a/src/test/java/team/rescue/cook/service/CookServiceTest.java
+++ b/src/test/java/team/rescue/cook/service/CookServiceTest.java
@@ -1,0 +1,262 @@
+package team.rescue.cook.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static team.rescue.error.type.ServiceError.INGREDIENT_NOT_FOUND;
+import static team.rescue.error.type.ServiceError.RECIPE_NOT_FOUND;
+import static team.rescue.error.type.ServiceError.USER_NOT_FOUND;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.rescue.auth.type.RoleType;
+import team.rescue.cook.dto.CookDto.CookCreateDto;
+import team.rescue.cook.dto.CookDto.CookInfoDto;
+import team.rescue.cook.entity.Cook;
+import team.rescue.cook.repository.CookRepository;
+import team.rescue.error.exception.ServiceException;
+import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientUseDto;
+import team.rescue.fridge.entity.Fridge;
+import team.rescue.fridge.entity.FridgeIngredient;
+import team.rescue.fridge.repository.FridgeIngredientRepository;
+import team.rescue.fridge.repository.FridgeRepository;
+import team.rescue.member.entity.Member;
+import team.rescue.member.repository.MemberRepository;
+import team.rescue.mock.WithMockMember;
+import team.rescue.recipe.entity.Recipe;
+import team.rescue.recipe.repository.RecipeRepository;
+
+@ExtendWith(MockitoExtension.class)
+class CookServiceTest {
+
+	@Mock
+	MemberRepository memberRepository;
+
+	@Mock
+	RecipeRepository recipeRepository;
+
+	@Mock
+	CookRepository cookRepository;
+
+	@Mock
+	FridgeIngredientRepository fridgeIngredientRepository;
+
+	@Mock
+	FridgeRepository fridgeRepository;
+
+	@InjectMocks
+	CookService cookService;
+
+	@Test
+	@DisplayName("요리 완료 성공")
+	@WithMockMember(role = RoleType.USER)
+	void successCompleteCook() {
+		// given
+		Member member = Member.builder()
+				.id(1L)
+				.email("test@gmail.com")
+				.build();
+
+		Fridge fridge = Fridge.builder()
+				.id(1L)
+				.member(member)
+				.build();
+
+		Recipe recipe = Recipe.builder()
+				.id(1L)
+				.title("양파 볶음")
+				.member(member)
+				.build();
+
+		FridgeIngredientUseDto fridgeIngredientUseDto = FridgeIngredientUseDto.builder()
+				.id(1L)
+				.memo("양파 2개")
+				.build();
+
+		List<FridgeIngredientUseDto> list = new ArrayList<>(
+				Collections.singletonList(fridgeIngredientUseDto));
+
+		FridgeIngredient fridgeIngredient = FridgeIngredient.builder()
+				.fridge(fridge)
+				.id(1L)
+				.name("양파")
+				.memo("양파 3개")
+				.build();
+
+		given(memberRepository.findUserByEmail("test@gmail.com"))
+				.willReturn(Optional.of(member));
+
+		given(fridgeIngredientRepository.findById(anyLong()))
+				.willReturn(Optional.of(fridgeIngredient));
+
+		FridgeIngredient updatedFridgeIngredient = FridgeIngredient.builder()
+				.id(1L)
+				.name("양파")
+				.memo("양파 2개")
+				.build();
+
+		given(fridgeIngredientRepository.save(any()))
+				.willReturn(updatedFridgeIngredient);
+
+		given(recipeRepository.findById(1L))
+				.willReturn(Optional.of(recipe));
+
+		Cook cook = Cook.builder()
+				.id(1L)
+				.recipe(recipe)
+				.member(member)
+				.createdAt(LocalDateTime.of(2024, 1, 12, 0, 0, 0))
+				.build();
+
+		given(cookRepository.save(any()))
+				.willReturn(cook);
+
+		// when
+		CookCreateDto cookCreateDto = CookCreateDto.builder()
+				.recipeId(1L)
+				.fridgeIngredientUseDtoList(list)
+				.build();
+
+		CookInfoDto cookInfoDto = cookService.completeCook(cookCreateDto, "test@gmail.com");
+
+		// then
+		assertEquals(1L, cookInfoDto.getId());
+		assertEquals(LocalDateTime.of(2024, 1, 12, 0, 0, 0), cookInfoDto.getCreatedAt());
+	}
+
+	@Test
+	@DisplayName("요리 완료 실패 - 사용자 정보 없음")
+	@WithMockMember(role = RoleType.USER)
+	void failCompleteCook_UserNotFound() {
+		// given
+		given(memberRepository.findUserByEmail("test@gmail.com"))
+				.willReturn(Optional.empty());
+
+		CookCreateDto cookCreateDto = CookCreateDto.builder()
+				.recipeId(1L)
+				.fridgeIngredientUseDtoList(null)
+				.build();
+
+		// when
+		ServiceException serviceException = assertThrows(ServiceException.class,
+				() -> cookService.completeCook(cookCreateDto, "test@gmail.com"));
+
+		// then
+		assertEquals(USER_NOT_FOUND.getHttpStatus(), serviceException.getStatusCode());
+	}
+
+	@Test
+	@DisplayName("요리 완료 실패 - 재료가 존재하지 않음")
+	@WithMockMember(role = RoleType.USER)
+	void failCompleteCook_IngredientNotFound() {
+		// given
+		Member member = Member.builder()
+				.id(1L)
+				.email("test@gmail.com")
+				.build();
+
+		given(memberRepository.findUserByEmail("test@gmail.com"))
+				.willReturn(Optional.of(member));
+
+		given(fridgeIngredientRepository.findById(1L))
+				.willReturn(Optional.empty());
+
+		FridgeIngredientUseDto fridgeIngredientUseDto = FridgeIngredientUseDto.builder()
+				.id(1L)
+				.memo("양파 2개")
+				.build();
+
+		List<FridgeIngredientUseDto> list = new ArrayList<>(
+				Collections.singletonList(fridgeIngredientUseDto));
+
+		CookCreateDto cookCreateDto = CookCreateDto.builder()
+				.recipeId(1L)
+				.fridgeIngredientUseDtoList(list)
+				.build();
+
+		// when
+		ServiceException serviceException = assertThrows(ServiceException.class,
+				() -> cookService.completeCook(cookCreateDto, "test@gmail.com"));
+
+		// then
+		assertEquals(INGREDIENT_NOT_FOUND.getHttpStatus(), serviceException.getStatusCode());
+	}
+
+	@Test
+	@DisplayName("요리 완료 실패 - 레시피 정보 없음")
+	@WithMockMember(role = RoleType.USER)
+	void failCompleteCook_RecipeNotFound() {
+		// given
+		Member member = Member.builder()
+				.id(1L)
+				.email("test@gmail.com")
+				.build();
+
+		Fridge fridge = Fridge.builder()
+				.id(1L)
+				.member(member)
+				.build();
+
+		Recipe recipe = Recipe.builder()
+				.id(1L)
+				.title("양파 볶음")
+				.member(member)
+				.build();
+
+		FridgeIngredientUseDto fridgeIngredientUseDto = FridgeIngredientUseDto.builder()
+				.id(1L)
+				.memo("양파 2개")
+				.build();
+
+		List<FridgeIngredientUseDto> list = new ArrayList<>(
+				Collections.singletonList(fridgeIngredientUseDto));
+
+		CookCreateDto cookCreateDto = CookCreateDto.builder()
+				.recipeId(1L)
+				.fridgeIngredientUseDtoList(list)
+				.build();
+
+		FridgeIngredient fridgeIngredient = FridgeIngredient.builder()
+				.fridge(fridge)
+				.id(1L)
+				.name("양파")
+				.memo("양파 3개")
+				.build();
+
+		given(memberRepository.findUserByEmail("test@gmail.com"))
+				.willReturn(Optional.of(member));
+
+		given(fridgeIngredientRepository.findById(anyLong()))
+				.willReturn(Optional.of(fridgeIngredient));
+
+		FridgeIngredient updatedFridgeIngredient = FridgeIngredient.builder()
+				.id(1L)
+				.name("양파")
+				.memo("양파 2개")
+				.build();
+
+		given(fridgeIngredientRepository.save(any()))
+				.willReturn(updatedFridgeIngredient);
+
+		given(recipeRepository.findById(1L))
+				.willReturn(Optional.empty());
+
+		// when
+		ServiceException serviceException = assertThrows(ServiceException.class,
+				() -> cookService.completeCook(cookCreateDto, "test@gmail.com"));
+
+		// then
+		assertEquals(RECIPE_NOT_FOUND.getHttpStatus(), serviceException.getStatusCode());
+	}
+}

--- a/src/test/java/team/rescue/recipe/controller/RecipeControllerTest.java
+++ b/src/test/java/team/rescue/recipe/controller/RecipeControllerTest.java
@@ -1,6 +1,5 @@
 package team.rescue.recipe.controller;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -29,7 +28,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import team.rescue.auth.type.ProviderType;
 import team.rescue.auth.type.RoleType;
-import team.rescue.auth.user.PrincipalDetails;
 import team.rescue.member.dto.MemberDto.MemberInfoDto;
 import team.rescue.member.entity.Member;
 import team.rescue.member.repository.MemberRepository;
@@ -211,8 +209,8 @@ class RecipeControllerTest extends MockMember {
         .recipeSteps(recipeStepCreateList)
         .build();
 
-    given(recipeService.addRecipe(any(RecipeCreateDto.class), any(PrincipalDetails.class)))
-        .willReturn(recipeCreateDto);
+//    given(recipeService.addRecipe(any(RecipeCreateDto.class), any(PrincipalDetails.class)))
+//        .willReturn(recipeCreateDto);
 
     objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
 


### PR DESCRIPTION
### 작업 내용 요약 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 변경점
<!---- 실제로 변경된 부분을 작성해주세요. -->
**AS-IS**


**TO-BE**
요리 완료 처리 기능 구현했습니다.
완료 처리 이전에 재료의 memo를 변경하여 fridgeIngredient의 memo 값을 수정합니다.

### 비고
<!---- 리뷰어에게 하고 싶은 말이나, 참고해야할 부분이 있다면 알려주세요. -->


### 테스트
<!---- 어떤 테스트를 진행했는지 적어주세요.-->

- [x] 테스트 코드 작성
- [x] API 테스트 
