### PR TITLE
특정 레시피 리뷰 목록 반환 #120

### DIFF
--- a/src/main/java/team/rescue/recipe/controller/RecipeController.java
+++ b/src/main/java/team/rescue/recipe/controller/RecipeController.java
@@ -2,6 +2,10 @@ package team.rescue.recipe.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -15,6 +19,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import team.rescue.auth.user.PrincipalDetails;
 import team.rescue.common.dto.ResponseDto;
@@ -24,6 +29,8 @@ import team.rescue.recipe.dto.RecipeDto.RecipeDetailDto;
 import team.rescue.recipe.dto.RecipeDto.RecipeInfoDto;
 import team.rescue.recipe.dto.RecipeDto.RecipeUpdateDto;
 import team.rescue.recipe.service.RecipeService;
+import team.rescue.review.dto.ReviewDto.ReviewInfoDto;
+import team.rescue.review.service.ReviewService;
 
 @Slf4j
 @RestController
@@ -32,6 +39,7 @@ import team.rescue.recipe.service.RecipeService;
 public class RecipeController {
 
 	private final RecipeService recipeService;
+	private final ReviewService reviewService;
 
 	/**
 	 * 특정 레시피 상세 조회
@@ -118,5 +126,33 @@ public class RecipeController {
 		} else {
 			return ResponseEntity.ok(new ResponseDto<>("레시피 북마크를 취소하였습니다.", bookmarkInfoDto));
 		}
+	}
+
+	/**
+	 * 특정 레시피의 리뷰 목록 조회
+	 *
+	 * @param recipeId 조회할 레시피 아이디
+	 * @param page     리뷰 목록 페이지 번호
+	 * @return 리뷰 목록
+	 */
+	@GetMapping("/{recipeId}/reviews")
+	@PreAuthorize("permitAll()")
+	public ResponseEntity<ResponseDto<Slice<ReviewInfoDto>>> getRecipeReviews(
+			@PathVariable Long recipeId,
+			@RequestParam(defaultValue = "0") Integer page
+	) {
+
+		// TODO: 이 부분 pageSize는 10으로 고정값인데 다르게 처리할 수 있을지?
+		PageRequest pageRequest = PageRequest.of(
+				page, 10, Sort.by(Direction.DESC, "createdAt")
+		);
+
+		Slice<ReviewInfoDto> recipeReviewList =
+				reviewService.getRecipeReviews(recipeId, pageRequest);
+
+		return new ResponseEntity<>(
+				new ResponseDto<>(null, recipeReviewList),
+				HttpStatus.OK
+		);
 	}
 }

--- a/src/main/java/team/rescue/review/controller/ReviewController.java
+++ b/src/main/java/team/rescue/review/controller/ReviewController.java
@@ -78,7 +78,7 @@ public class ReviewController {
 
 		return new ResponseEntity<>(
 				new ResponseDto<>(null, reviewDetailDto),
-				HttpStatus.CREATED
+				HttpStatus.OK
 		);
 	}
 

--- a/src/main/java/team/rescue/review/controller/ReviewController.java
+++ b/src/main/java/team/rescue/review/controller/ReviewController.java
@@ -2,10 +2,6 @@ package team.rescue.review.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -18,7 +14,6 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -135,34 +130,6 @@ public class ReviewController {
 
 		return new ResponseEntity<>(
 				new ResponseDto<>("리뷰를 삭제했습니다.", reviewInfoDto),
-				HttpStatus.OK
-		);
-	}
-
-	/**
-	 * 특정 레시피의 리뷰 목록 조회
-	 *
-	 * @param recipeId 조회할 레시피 아이디
-	 * @param page     리뷰 목록 페이지 번호
-	 * @return 리뷰 목록
-	 */
-	@GetMapping("/{recipeId}/reviews")
-	@PreAuthorize("permitAll()")
-	public ResponseEntity<ResponseDto<Slice<ReviewInfoDto>>> getRecipeReviews(
-			@PathVariable Long recipeId,
-			@RequestParam(defaultValue = "0") Integer page
-	) {
-
-		// TODO: 이 부분 pageSize는 10으로 고정값인데 다르게 처리할 수 있을지?
-		PageRequest pageRequest = PageRequest.of(
-				page, 10, Sort.by(Direction.DESC, "createdAt")
-		);
-
-		Slice<ReviewInfoDto> recipeReviewList =
-				reviewService.getRecipeReviews(recipeId, pageRequest);
-
-		return new ResponseEntity<>(
-				new ResponseDto<>(null, recipeReviewList),
 				HttpStatus.OK
 		);
 	}

--- a/src/main/java/team/rescue/review/controller/ReviewController.java
+++ b/src/main/java/team/rescue/review/controller/ReviewController.java
@@ -2,6 +2,10 @@ package team.rescue.review.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -14,6 +18,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -134,4 +139,31 @@ public class ReviewController {
 		);
 	}
 
+	/**
+	 * 특정 레시피의 리뷰 목록 조회
+	 *
+	 * @param recipeId 조회할 레시피 아이디
+	 * @param page     리뷰 목록 페이지 번호
+	 * @return 리뷰 목록
+	 */
+	@GetMapping("/{recipeId}/reviews")
+	@PreAuthorize("permitAll()")
+	public ResponseEntity<ResponseDto<Slice<ReviewInfoDto>>> getRecipeReviews(
+			@PathVariable Long recipeId,
+			@RequestParam(defaultValue = "0") Integer page
+	) {
+
+		// TODO: 이 부분 pageSize는 10으로 고정값인데 다르게 처리할 수 있을지?
+		PageRequest pageRequest = PageRequest.of(
+				page, 10, Sort.by(Direction.DESC, "createdAt")
+		);
+
+		Slice<ReviewInfoDto> recipeReviewList =
+				reviewService.getRecipeReviews(recipeId, pageRequest);
+
+		return new ResponseEntity<>(
+				new ResponseDto<>(null, recipeReviewList),
+				HttpStatus.OK
+		);
+	}
 }

--- a/src/main/java/team/rescue/review/dto/ReviewDto.java
+++ b/src/main/java/team/rescue/review/dto/ReviewDto.java
@@ -42,6 +42,7 @@ public class ReviewDto {
 
 		private Long id;
 		private String title;
+		private String contents;
 		private String imageUrl;
 		private MemberInfoDto author;
 
@@ -50,6 +51,7 @@ public class ReviewDto {
 			ReviewInfoDto reviewInfo = new ReviewInfoDto();
 			reviewInfo.setId(review.getId());
 			reviewInfo.setTitle(review.getTitle());
+			reviewInfo.setContents(review.getContents());
 			reviewInfo.setImageUrl(review.getImageUrl());
 			reviewInfo.setAuthor(MemberInfoDto.of(review.getMember()));
 

--- a/src/main/java/team/rescue/review/repository/ReviewRepository.java
+++ b/src/main/java/team/rescue/review/repository/ReviewRepository.java
@@ -1,6 +1,5 @@
 package team.rescue.review.repository;
 
-import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -15,6 +14,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
 	List<Review> findByCook(Cook cook);
 
-	@Query("select r from Review r where r.recipe.id = :recipeId")
-	Slice<Review> findByRecipeId(@Param("recipeId") Long recipeId, PageRequest pageRequest);
+	@Query("select r from Review r join fetch r.member where r.recipe.id = :recipeId")
+	Slice<Review> findReviewsByRecipeId(Long recipeId, PageRequest pageRequest);
 }

--- a/src/main/java/team/rescue/review/repository/ReviewRepository.java
+++ b/src/main/java/team/rescue/review/repository/ReviewRepository.java
@@ -1,7 +1,11 @@
 package team.rescue.review.repository;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import team.rescue.cook.entity.Cook;
 import team.rescue.review.entity.Review;
@@ -10,4 +14,7 @@ import team.rescue.review.entity.Review;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
 	List<Review> findByCook(Cook cook);
+
+	@Query("select r from Review r where r.recipe.id = :recipeId")
+	Slice<Review> findByRecipeId(@Param("recipeId") Long recipeId, PageRequest pageRequest);
 }

--- a/src/main/java/team/rescue/review/service/ReviewService.java
+++ b/src/main/java/team/rescue/review/service/ReviewService.java
@@ -160,11 +160,9 @@ public class ReviewService {
 		log.info("[레시피 리뷰 목록 조회] recipeId={}", recipeId);
 
 		// 해당 레시피 아이디로 리뷰 조회
-		Slice<Review> reviewList =
-				reviewRepository.findByRecipeId(recipeId, pageRequest);
+		Slice<Review> reviewList = reviewRepository.findReviewsByRecipeId(recipeId, pageRequest);
 
 		return reviewList.map(ReviewInfoDto::of);
-
 	}
 
 	/**

--- a/src/main/java/team/rescue/review/service/ReviewService.java
+++ b/src/main/java/team/rescue/review/service/ReviewService.java
@@ -3,6 +3,8 @@ package team.rescue.review.service;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -148,6 +150,21 @@ public class ReviewService {
 		recipeRepository.save(recipe);
 
 		return ReviewInfoDto.of(review);
+	}
+
+	public Slice<ReviewInfoDto> getRecipeReviews(
+			Long recipeId,
+			PageRequest pageRequest
+	) {
+
+		log.info("[레시피 리뷰 목록 조회] recipeId={}", recipeId);
+
+		// 해당 레시피 아이디로 리뷰 조회
+		Slice<Review> reviewList =
+				reviewRepository.findByRecipeId(recipeId, pageRequest);
+
+		return reviewList.map(ReviewInfoDto::of);
+
 	}
 
 	/**

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -24,7 +24,7 @@ spring:
       hibernate:
         default_batch_fetch_size: 100
         format_sql: true
-      show_sql: true
+        show_sql: true
   output:
     ansi:
       enabled: always


### PR DESCRIPTION
### 작업 내용 요약 
- GET/{recipeId}/reviews?page={page} 요청 시 해당 레시피 ID 하위에 등록된 리뷰를 최신 순으로 10개씩 가져옵니다.

### 변경점
#### Fetch Join으로 DTO 생성할 수 있도록 처리
- ReviewInfoDto에서 멤버에 대한 간략한 데이터를 가지고 있어야 하므로 조회 시 member 테이블 조회 하도록 처리했습니다. 
   N+1 문제 해소를 위하 fetch join으로 처리했습니다.
```java
@Query("select r from Review r join fetch r.member where r.recipe.id = :recipeId")
Slice<Review> findReviewsByRecipeId(Long recipeId, PageRequest pageRequest);
```


### 비고
<!---- 리뷰어에게 하고 싶은 말이나, 참고해야할 부분이 있다면 알려주세요. -->


### 테스트
<!---- 어떤 테스트를 진행했는지 적어주세요.-->

- [ ] 테스트 코드 작성
- [ ] API 테스트 
