### PR TITLE
회원 비밀번호 변경 요청 DTO와 에러메시지 수정 #133

### DIFF
--- a/src/main/java/team/rescue/error/type/ServiceError.java
+++ b/src/main/java/team/rescue/error/type/ServiceError.java
@@ -25,8 +25,7 @@ public enum ServiceError {
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
 	EMAIL_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
 	EMAIL_CODE_MIS_MATCH(HttpStatus.BAD_REQUEST, "이메일 인증 코드가 일치하지 않습니다."),
-	USER_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
-	PASSWORD_AND_PASSWORD_CHECK_MISMATCH(HttpStatus.BAD_REQUEST, "새 비밀번호와 비밀번호 확인 값이 일치하지 않습니다."),
+	USER_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "현재 비밀번호를 확인해주세요."),
 
 	// Recipe
 	RECIPE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 레시피를 찾을 수 없습니다."),

--- a/src/main/java/team/rescue/member/dto/MemberDto.java
+++ b/src/main/java/team/rescue/member/dto/MemberDto.java
@@ -75,8 +75,5 @@ public class MemberDto {
 		@NotEmpty(message = "변경할 새 비밀번호를 입력해주세요.")
 		@Size(max = 20, message = "최대 20글자의 비밀번호를 입력해주세요.")
 		private String newPassword;
-
-		@NotEmpty(message = "변경할 새 비밀번호를 한 번 더 입력해주세요.")
-		private String newPasswordCheck;
 	}
 }

--- a/src/main/java/team/rescue/member/service/MemberService.java
+++ b/src/main/java/team/rescue/member/service/MemberService.java
@@ -3,7 +3,6 @@ package team.rescue.member.service;
 import static team.rescue.error.type.ServiceError.USER_NOT_FOUND;
 import static team.rescue.error.type.ServiceError.USER_PASSWORD_MISMATCH;
 
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -15,7 +14,6 @@ import team.rescue.cook.dto.CookDto.CookInfoDto;
 import team.rescue.cook.entity.Cook;
 import team.rescue.cook.repository.CookRepository;
 import team.rescue.error.exception.ServiceException;
-import team.rescue.error.type.ServiceError;
 import team.rescue.member.dto.MemberDto.MemberDetailDto;
 import team.rescue.member.dto.MemberDto.MemberNicknameUpdateDto;
 import team.rescue.member.dto.MemberDto.MemberPasswordUpdateDto;
@@ -70,11 +68,6 @@ public class MemberService {
 
 		if (!passwordMatch) {
 			throw new ServiceException(USER_PASSWORD_MISMATCH);
-		}
-
-		if (!Objects.equals(memberPasswordUpdateDto.getNewPassword(),
-				memberPasswordUpdateDto.getNewPasswordCheck())) {
-			throw new ServiceException(ServiceError.PASSWORD_AND_PASSWORD_CHECK_MISMATCH);
 		}
 
 		member.updatePassword(passwordEncoder.encode(memberPasswordUpdateDto.getNewPassword()));

--- a/src/test/java/team/rescue/member/controller/MemberControllerTest.java
+++ b/src/test/java/team/rescue/member/controller/MemberControllerTest.java
@@ -123,7 +123,6 @@ class MemberControllerTest extends MockMember {
 		MemberPasswordUpdateDto memberPasswordUpdateDto = MemberPasswordUpdateDto.builder()
 				.currentPassword("asdfasdfasdf")
 				.newPassword("qwerqwerqwer")
-				.newPasswordCheck("qwerqwerqwer")
 				.build();
 
 		given(memberService.updateMemberPassword("test@gmail.com", memberPasswordUpdateDto))

--- a/src/test/java/team/rescue/member/service/MemberServiceTest.java
+++ b/src/test/java/team/rescue/member/service/MemberServiceTest.java
@@ -5,16 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static team.rescue.error.type.ServiceError.PASSWORD_AND_PASSWORD_CHECK_MISMATCH;
 import static team.rescue.error.type.ServiceError.USER_NOT_FOUND;
 import static team.rescue.error.type.ServiceError.USER_PASSWORD_MISMATCH;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -164,7 +160,6 @@ class MemberServiceTest {
 		MemberPasswordUpdateDto memberPasswordUpdateDto = MemberPasswordUpdateDto.builder()
 				.currentPassword("1234567890")
 				.newPassword("0987654321")
-				.newPasswordCheck("0987654321")
 				.build();
 
 		given(memberRepository.findUserByEmail("test@gmail.com"))
@@ -220,7 +215,6 @@ class MemberServiceTest {
 		MemberPasswordUpdateDto memberPasswordUpdateDto = MemberPasswordUpdateDto.builder()
 				.currentPassword("1234567890")
 				.newPassword("0987654321")
-				.newPasswordCheck("0987654321")
 				.build();
 
 		given(memberRepository.findUserByEmail("test@gmail.com"))
@@ -236,41 +230,6 @@ class MemberServiceTest {
 
 		// then
 		assertEquals(USER_PASSWORD_MISMATCH.getHttpStatus(), serviceException.getStatusCode());
-	}
-
-	@Test
-	@DisplayName("회원 비밀번호 변경 실패 - 새 비밀번호와 비밀번호 확인 불일치")
-	void failUpdateMemberPassword_PasswordAndPasswordCheckMismatch() {
-		// given
-		Member member = Member.builder()
-				.id(1L)
-				.nickname("테스트")
-				.email("test@gmail.com")
-				.password("1234567890")
-				.build();
-
-		MemberPasswordUpdateDto memberPasswordUpdateDto = MemberPasswordUpdateDto.builder()
-				.currentPassword("1234567890")
-				.newPassword("0987654321")
-				.newPasswordCheck("123124124")
-				.build();
-
-		// when
-		ServiceException serviceException = assertThrows(ServiceException.class,
-				() -> passwordAndPasswordCheckMismatch(memberPasswordUpdateDto));
-
-		// then
-		assertEquals(PASSWORD_AND_PASSWORD_CHECK_MISMATCH.getHttpStatus(),
-				serviceException.getStatusCode());
-		verify(memberRepository, never()).save(any());
-	}
-
-	private void passwordAndPasswordCheckMismatch(
-			MemberPasswordUpdateDto memberPasswordUpdateDto) {
-		if (!Objects.equals(memberPasswordUpdateDto.getNewPassword(),
-				memberPasswordUpdateDto.getNewPasswordCheck())) {
-			throw new ServiceException(PASSWORD_AND_PASSWORD_CHECK_MISMATCH);
-		}
 	}
 
 	@Test


### PR DESCRIPTION
### 작업 내용 요약 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 변경점
<!---- 실제로 변경된 부분을 작성해주세요. -->
**AS-IS**
회원 비밀번호 변경 DTO에 현재 비밀번호, 새 비밀번호, 새 비밀번호 확인 필드가 있었음

**TO-BE**
프론트에서 비밀번호 확인 검증을 하면 된다고 하여 현재 비밀번호와 새 비밀번호만 입력받도록 수정.
현재 비밀번호가 일치하지 않을 때 에러메시지 "비밀번호가 일치하지 않습니다." -> "현재 비밀번호를 확인해주세요" 로 수정

### 비고
<!---- 리뷰어에게 하고 싶은 말이나, 참고해야할 부분이 있다면 알려주세요. -->


### 테스트
<!---- 어떤 테스트를 진행했는지 적어주세요.-->

- [ ] 테스트 코드 작성
- [ ] API 테스트 
