### PR TITLE
JWT 토큰 응답값 변경 #135

### DIFF
--- a/src/main/java/team/rescue/auth/dto/LoginDto.java
+++ b/src/main/java/team/rescue/auth/dto/LoginDto.java
@@ -21,11 +21,13 @@ public class LoginDto {
 		private final Long id;
 		private final String nickname;
 		private final RoleType roleType;
+		private final String token;
 
-		public LoginResDto(Member user) {
+		public LoginResDto(Member user, String token) {
 			this.id = user.getId();
 			this.nickname = user.getNickname();
 			this.roleType = user.getRole();
+			this.token = token;
 		}
 	}
 }

--- a/src/main/java/team/rescue/auth/dto/TokenDto.java
+++ b/src/main/java/team/rescue/auth/dto/TokenDto.java
@@ -9,5 +9,4 @@ public class TokenDto {
 
 	private final String accessToken;
 	private final String refreshToken;
-
 }

--- a/src/main/java/team/rescue/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/team/rescue/auth/filter/JwtAuthenticationFilter.java
@@ -103,14 +103,13 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 		// redis 저장
 		redisUtil.put(principalDetails.getUsername(), refreshToken, REFRESH_TOKEN_EXPIRE_TIME);
 
-		LoginResDto loginResponse = new LoginResDto(principalDetails.getMember());
+		LoginResDto loginResponse = new LoginResDto(principalDetails.getMember(), accessToken);
 
 		response.setStatus(HttpStatus.OK.value());
 		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
 		// access token, refresh token을 Header에 담아서 클라이언트에게 전달
-		response.setHeader(HEADER_ACCESS_TOKEN, TOKEN_PREFIX + accessToken);
-		response.setHeader(HEADER_REFRESH_TOKEN, TOKEN_PREFIX + refreshToken);
+		response.setHeader(HEADER_REFRESH_TOKEN, refreshToken);
 
 		new ObjectMapper().writeValue(response.getOutputStream(), loginResponse);
 

--- a/src/main/java/team/rescue/auth/handler/OAuthAuthorizationSuccessHandler.java
+++ b/src/main/java/team/rescue/auth/handler/OAuthAuthorizationSuccessHandler.java
@@ -55,7 +55,7 @@ public class OAuthAuthorizationSuccessHandler implements AuthenticationSuccessHa
 
 		redisUtil.put(principalDetails.getUsername(), refreshToken, REFRESH_TOKEN_EXPIRE_TIME);
 
-		LoginResDto loginResponse = new LoginResDto(principalDetails.getMember());
+		LoginResDto loginResponse = new LoginResDto(principalDetails.getMember(), accessToken);
 
 		response.setStatus(HttpStatus.OK.value());
 		response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/team/rescue/auth/handler/OAuthAuthorizationSuccessHandler.java
+++ b/src/main/java/team/rescue/auth/handler/OAuthAuthorizationSuccessHandler.java
@@ -55,13 +55,13 @@ public class OAuthAuthorizationSuccessHandler implements AuthenticationSuccessHa
 
 		redisUtil.put(principalDetails.getUsername(), refreshToken, REFRESH_TOKEN_EXPIRE_TIME);
 
+		// access token은 Response Body에 담아서 클라이언트에게 전달
 		LoginResDto loginResponse = new LoginResDto(principalDetails.getMember(), accessToken);
 
 		response.setStatus(HttpStatus.OK.value());
 		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
-		// access token, refresh token을 Header에 담아서 클라이언트에게 전달
-		response.setHeader(HEADER_ACCESS_TOKEN, TOKEN_PREFIX + accessToken);
+		// refresh token을 Header에 담아서 클라이언트에게 전달
 		response.setHeader(HEADER_REFRESH_TOKEN, TOKEN_PREFIX + refreshToken);
 
 		new ObjectMapper().writeValue(response.getOutputStream(), loginResponse);


### PR DESCRIPTION
### 작업 내용 요약 
- Access Token은 Response Body
- Refresh Token은 Header
- 응답에서 Bearer Prefix 제외

### 변경점
#### Access Token은 Response Body에 태워 응답합니다.
따라서 로그인 응답 DTO를 다음과 같이 변경했습니다.
LoginResDto 생성 시 파라미터로 String token을 추가로 받습니다.

```java
@Getter
public static class LoginResDto {
	private final Long id;
	private final String nickname;
	private final RoleType roleType;
	private final String token;

	public LoginResDto(Member user, String token) {
		this.id = user.getId();
		this.nickname = user.getNickname();
		this.roleType = user.getRole();
		this.token = token;
	}
}
```

#### Refresh Token은 Header에 태워서 응답합니다.
- LoginResDto 생성 시, access token 값을 같이 넘겨줍니다.
- 클래스에서 HEADER_ACCESS_TOKEN 필드를 제거했습니다.
- Header로 Refresh Token을 넘길 때 Bearer 프리픽스를 제거했습니다.
  서버에서 응답으로 나가는 Token에는 굳이 Prefix를 붙이지 않고, 프론트에서 백단으로 요청 줄 때 Bearer를 붙여서 보냅니다.

```java
// Email 로그인
// access token을 Response Body에 담아서 클라이언트에게 전달
LoginResDto loginResponse = new LoginResDto(principalDetails.getMember(), accessToken);

response.setStatus(HttpStatus.OK.value());
response.setContentType(MediaType.APPLICATION_JSON_VALUE);

// refresh token을 Header에 담아서 클라이언트에게 전달
response.setHeader(HEADER_REFRESH_TOKEN, refreshToken);
```
```java
// OAuth 로그인
// access token은 Response Body에 담아서 클라이언트에게 전달
LoginResDto loginResponse = new LoginResDto(principalDetails.getMember(), accessToken);

response.setStatus(HttpStatus.OK.value());
response.setContentType(MediaType.APPLICATION_JSON_VALUE);

// refresh token을 Header에 담아서 클라이언트에게 전달
response.setHeader(HEADER_REFRESH_TOKEN, refreshToken);
```

### 비고
<!---- 리뷰어에게 하고 싶은 말이나, 참고해야할 부분이 있다면 알려주세요. -->


### 테스트
<!---- 어떤 테스트를 진행했는지 적어주세요.-->

- [ ] 테스트 코드 작성
- [ ] API 테스트 
