### PR TITLE
요리 완료 로직 DTO 수정 #156

### DIFF
--- a/src/main/java/team/rescue/cook/dto/CookDto.java
+++ b/src/main/java/team/rescue/cook/dto/CookDto.java
@@ -35,7 +35,8 @@ public class CookDto {
 	public static class CookCreateDto {
 
 		private Long recipeId;
-		private List<FridgeIngredientUseDto> fridgeIngredientUseDtoList;
+		private List<Long> delete;
+		private List<FridgeIngredientUseDto> update;
 	}
 
 }

--- a/src/main/java/team/rescue/cook/service/CookService.java
+++ b/src/main/java/team/rescue/cook/service/CookService.java
@@ -17,7 +17,6 @@ import team.rescue.error.exception.ServiceException;
 import team.rescue.fridge.dto.FridgeIngredientDto.FridgeIngredientUseDto;
 import team.rescue.fridge.entity.FridgeIngredient;
 import team.rescue.fridge.repository.FridgeIngredientRepository;
-import team.rescue.fridge.repository.FridgeRepository;
 import team.rescue.member.entity.Member;
 import team.rescue.member.repository.MemberRepository;
 import team.rescue.recipe.entity.Recipe;
@@ -33,14 +32,19 @@ public class CookService {
 	private final RecipeRepository recipeRepository;
 	private final CookRepository cookRepository;
 	private final FridgeIngredientRepository fridgeIngredientRepository;
-	private final FridgeRepository fridgeRepository;
 
 	@Transactional
 	public CookInfoDto completeCook(CookCreateDto cookCreateDto, String email) {
 		Member member = memberRepository.findUserByEmail(email)
 				.orElseThrow(() -> new ServiceException(USER_NOT_FOUND));
 
-		List<FridgeIngredientUseDto> fridgeIngredientUseDtoList = cookCreateDto.getFridgeIngredientUseDtoList();
+		List<Long> deleteList = cookCreateDto.getDelete();
+
+		for (Long id : deleteList) {
+			fridgeIngredientRepository.deleteById(id);
+		}
+
+		List<FridgeIngredientUseDto> fridgeIngredientUseDtoList = cookCreateDto.getUpdate();
 
 		for (FridgeIngredientUseDto fridgeIngredientUseDto : fridgeIngredientUseDtoList) {
 			FridgeIngredient fridgeIngredient = fridgeIngredientRepository.findById(

--- a/src/test/java/team/rescue/cook/controller/CookControllerTest.java
+++ b/src/test/java/team/rescue/cook/controller/CookControllerTest.java
@@ -67,6 +67,8 @@ class CookControllerTest {
 				.memo("당근 반개")
 				.build();
 
+		List<Long> deleteList = new ArrayList<>(1);
+
 		List<FridgeIngredientUseDto> list = new ArrayList<>(
 				Arrays.asList(fridgeIngredientUseDto1, fridgeIngredientUseDto2));
 
@@ -77,7 +79,8 @@ class CookControllerTest {
 						.content(objectMapper.writeValueAsString(
 								CookCreateDto.builder()
 										.recipeId(1L)
-										.fridgeIngredientUseDtoList(list)
+										.delete(deleteList)
+										.update(list)
 										.build()
 						)))
 				.andExpect(status().isOk())

--- a/src/test/java/team/rescue/cook/service/CookServiceTest.java
+++ b/src/test/java/team/rescue/cook/service/CookServiceTest.java
@@ -125,7 +125,8 @@ class CookServiceTest {
 		// when
 		CookCreateDto cookCreateDto = CookCreateDto.builder()
 				.recipeId(1L)
-				.fridgeIngredientUseDtoList(list)
+				.delete(new ArrayList<>())
+				.update(list)
 				.build();
 
 		CookInfoDto cookInfoDto = cookService.completeCook(cookCreateDto, "test@gmail.com");
@@ -145,7 +146,7 @@ class CookServiceTest {
 
 		CookCreateDto cookCreateDto = CookCreateDto.builder()
 				.recipeId(1L)
-				.fridgeIngredientUseDtoList(null)
+				.update(null)
 				.build();
 
 		// when
@@ -182,7 +183,8 @@ class CookServiceTest {
 
 		CookCreateDto cookCreateDto = CookCreateDto.builder()
 				.recipeId(1L)
-				.fridgeIngredientUseDtoList(list)
+				.delete(new ArrayList<>())
+				.update(list)
 				.build();
 
 		// when
@@ -224,7 +226,8 @@ class CookServiceTest {
 
 		CookCreateDto cookCreateDto = CookCreateDto.builder()
 				.recipeId(1L)
-				.fridgeIngredientUseDtoList(list)
+				.delete(new ArrayList<>())
+				.update(list)
 				.build();
 
 		FridgeIngredient fridgeIngredient = FridgeIngredient.builder()


### PR DESCRIPTION
### 작업 내용 요약 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 변경점
<!---- 실제로 변경된 부분을 작성해주세요. -->
**AS-IS**
요리 완료 로직에서 기존에는 recipeId와 List<FridgeIngredientUseDto>를 받았음


**TO-BE**
recipeId 값과 List<Long> 타입의 delete와, List<FridgeIngredientUseDto> 타입의 update를 사용해 사용된 재료를 처리하도록 함

### 비고
<!---- 리뷰어에게 하고 싶은 말이나, 참고해야할 부분이 있다면 알려주세요. -->


### 테스트
<!---- 어떤 테스트를 진행했는지 적어주세요.-->

- [ ] 테스트 코드 작성
- [ ] API 테스트 
