### PR TITLE
토큰 재발급 요청 로직 수정 #159

### DIFF
--- a/src/main/java/team/rescue/auth/controller/AuthController.java
+++ b/src/main/java/team/rescue/auth/controller/AuthController.java
@@ -129,9 +129,9 @@ public class AuthController {
 	 * @param principalDetails 사용자 정보
 	 */
 	@PostMapping("/token/reissue")
-	@PreAuthorize("hasAuthority('USER')")
+	@PreAuthorize("hasAuthority('USER') or hasAuthority('GUEST')")
 	public ResponseEntity<ResponseDto<String>> reissueToken(
-			@RequestHeader(HEADER_REFRESH_TOKEN) String refreshToken,
+			@RequestHeader("Authorization") String refreshToken,
 			@AuthenticationPrincipal PrincipalDetails principalDetails) {
 
 		log.debug("Refresh Token : {}", refreshToken);

--- a/src/main/java/team/rescue/auth/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/team/rescue/auth/filter/JwtAuthorizationFilter.java
@@ -66,7 +66,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
 //      body.put("code", AuthError.EXPIRED_ACCESS_TOKEN.getHttpStatus());
 //      body.put("error", AuthError.EXPIRED_ACCESS_TOKEN.getErrorMessage());
 			body.put("code", "401 Unauthorized");
-			body.put("error", "만료된 액세스 토큰");
+			body.put("error", "만료된 토큰");
 
 			// JSON으로 변환하여 응답 스트림에 작성
 			new ObjectMapper().writeValue(response.getOutputStream(), body);

--- a/src/main/java/team/rescue/auth/service/AuthService.java
+++ b/src/main/java/team/rescue/auth/service/AuthService.java
@@ -180,11 +180,6 @@ public class AuthService implements UserDetailsService {
 		String savedToken =
 				cachedRefreshToken == null ? getTokenFromDB(principalDetails) : cachedRefreshToken;
 
-		// refreshToken 만료 -> 다시 로그인 필요 (재로그인을 하면 accessToken, refreshToken 갱신)
-		if (JwtTokenProvider.isExpiredToken(refreshToken)) {
-			throw new AuthException(AuthError.EXPIRED_REFRESH_TOKEN);
-		}
-
 		// refreshToken 불일치 -> 다시 로그인 필요 (재로그인을 하면 accessToken, refreshToken 갱신)
 		if (!Objects.equals(refreshToken, savedToken)) {
 			throw new AuthException(AuthError.ACCESS_DENIED);


### PR DESCRIPTION
### 작업 내용 요약 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 변경점
<!---- 실제로 변경된 부분을 작성해주세요. -->
**AS-IS**
토큰 재발급 요청에 access token을 태워 보내면 access token이 만료되서 요청을 보내는 것인데 또 만료된 엑세스 토큰 에러가 발생

**TO-BE**
헤더에 refresh token을 입력하도록 하고 그 값을 통해 검증하는 것으로 수정

### 비고
<!---- 리뷰어에게 하고 싶은 말이나, 참고해야할 부분이 있다면 알려주세요. -->


### 테스트
<!---- 어떤 테스트를 진행했는지 적어주세요.-->

- [ ] 테스트 코드 작성
- [ ] API 테스트 
