### PR TITLE
이메일 가입 유저 탈퇴 시 enable false 처리 #199

### DIFF
--- a/src/main/java/team/rescue/auth/controller/AuthController.java
+++ b/src/main/java/team/rescue/auth/controller/AuthController.java
@@ -123,7 +123,7 @@ public class AuthController {
 
 		String email = principalDetails.getUsername();
 
-		authService.deleteMember(email);
+		authService.disableMember(email);
 
 		return ResponseEntity.ok(new ResponseDto<>("회원 탈퇴가 정상적으로 처리되었습니다.", null));
 	}

--- a/src/main/java/team/rescue/auth/user/PrincipalDetails.java
+++ b/src/main/java/team/rescue/auth/user/PrincipalDetails.java
@@ -59,7 +59,7 @@ public class PrincipalDetails implements UserDetails, OAuth2User {
 
 	@Override
 	public boolean isEnabled() {
-		return true;
+		return this.member.getIsEnabled();
 	}
 
 	@Override

--- a/src/main/java/team/rescue/error/type/ServiceError.java
+++ b/src/main/java/team/rescue/error/type/ServiceError.java
@@ -21,6 +21,7 @@ public enum ServiceError {
 	FILE_DELETION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제를 실패했습니다."),
 
 	// User
+	USER_ALREADY_LEAVE(HttpStatus.BAD_REQUEST, "이미 탈퇴한 회원입니다."),
 	EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "등록되지 않은 이메일입니다."),
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
 	EMAIL_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),

--- a/src/main/java/team/rescue/member/entity/Member.java
+++ b/src/main/java/team/rescue/member/entity/Member.java
@@ -70,6 +70,9 @@ public class Member {
 	@Column(name = "jwt_token")
 	private String token;
 
+	@Column(name = "is_enabled", nullable = false)
+	private Boolean isEnabled;
+
 	@OneToOne(mappedBy = "member")
 	private Fridge fridge;
 
@@ -118,6 +121,11 @@ public class Member {
 
 	public void updatePassword(String password) {
 		this.password = password;
+	}
+
+	// 회원 탈퇴
+	public void leave() {
+		this.isEnabled = false;
 	}
 }
 

--- a/src/main/java/team/rescue/member/service/MemberService.java
+++ b/src/main/java/team/rescue/member/service/MemberService.java
@@ -14,6 +14,7 @@ import team.rescue.cook.dto.CookDto.CookInfoDto;
 import team.rescue.cook.entity.Cook;
 import team.rescue.cook.repository.CookRepository;
 import team.rescue.error.exception.ServiceException;
+import team.rescue.error.type.ServiceError;
 import team.rescue.member.dto.MemberDto.MemberDetailDto;
 import team.rescue.member.dto.MemberDto.MemberNicknameUpdateDto;
 import team.rescue.member.dto.MemberDto.MemberPasswordUpdateDto;
@@ -41,6 +42,8 @@ public class MemberService {
 		Member member = memberRepository.findUserByEmail(email)
 				.orElseThrow(() -> new ServiceException(USER_NOT_FOUND));
 
+		validateMember(member);
+		
 		return MemberDetailDto.of(member);
 	}
 
@@ -49,6 +52,8 @@ public class MemberService {
 			MemberNicknameUpdateDto memberNicknameUpdateDto) {
 		Member member = memberRepository.findUserByEmail(email)
 				.orElseThrow(() -> new ServiceException(USER_NOT_FOUND));
+
+		validateMember(member);
 
 		member.updateNickname(memberNicknameUpdateDto.getNickname());
 
@@ -62,6 +67,8 @@ public class MemberService {
 			MemberPasswordUpdateDto memberPasswordUpdateDto) {
 		Member member = memberRepository.findUserByEmail(email)
 				.orElseThrow(() -> new ServiceException(USER_NOT_FOUND));
+
+		validateMember(member);
 
 		boolean passwordMatch = passwordEncoder.matches(memberPasswordUpdateDto.getCurrentPassword(),
 				member.getPassword());
@@ -81,6 +88,8 @@ public class MemberService {
 		Member member = memberRepository.findUserByEmail(email)
 				.orElseThrow(() -> new ServiceException(USER_NOT_FOUND));
 
+		validateMember(member);
+
 		Page<Cook> cookPage = cookRepository.findByMember(member, pageable);
 
 		return cookPage.map(CookInfoDto::of);
@@ -89,6 +98,8 @@ public class MemberService {
 	public Page<RecipeInfoDto> getMyRecipes(String email, Pageable pageable) {
 		Member member = memberRepository.findUserByEmail(email)
 				.orElseThrow(() -> new ServiceException(USER_NOT_FOUND));
+
+		validateMember(member);
 
 		Page<Recipe> recipePage = recipeRepository.findByMember(member, pageable);
 
@@ -99,8 +110,23 @@ public class MemberService {
 		Member member = memberRepository.findUserByEmail(email)
 				.orElseThrow(() -> new ServiceException(USER_NOT_FOUND));
 
+		validateMember(member);
+
 		Page<Bookmark> bookmarkPage = bookmarkRepository.findByMember(member, pageable);
 
 		return bookmarkPage.map(bookmark -> RecipeInfoDto.of(bookmark.getRecipe()));
+	}
+
+	/**
+	 * 탈퇴 유저 검증
+	 *
+	 * @param member 검증할 유저
+	 */
+	private void validateMember(Member member) {
+
+		// 탈퇴한 멤버 조회 시
+		if (!member.getIsEnabled()) {
+			throw new ServiceException(ServiceError.USER_ALREADY_LEAVE);
+		}
 	}
 }

--- a/src/test/java/team/rescue/auth/controller/AuthControllerTest.java
+++ b/src/test/java/team/rescue/auth/controller/AuthControllerTest.java
@@ -139,7 +139,7 @@ class AuthControllerTest extends MockMember {
 	@WithMockMember(role = RoleType.USER)
 	void successDeleteMember() throws Exception {
 		// given
-		doNothing().when(authService).deleteMember("test@gmail.com");
+		doNothing().when(authService).disableMember("test@gmail.com");
 
 		// when
 		// then

--- a/src/test/java/team/rescue/auth/service/AuthServiceTest.java
+++ b/src/test/java/team/rescue/auth/service/AuthServiceTest.java
@@ -261,7 +261,7 @@ class AuthServiceTest {
 				.willReturn(Optional.of(member));
 
 		// when
-		authService.deleteMember("test@gmail.com");
+		authService.disableMember("test@gmail.com");
 
 		// then
 		verify(fridgeRepository, times(1)).deleteByMember(any());
@@ -278,7 +278,7 @@ class AuthServiceTest {
 
 		// when
 		ServiceException serviceException = assertThrows(ServiceException.class,
-				() -> authService.deleteMember("test@gmail.com"));
+				() -> authService.disableMember("test@gmail.com"));
 
 		// then
 		assertEquals(ServiceError.USER_NOT_FOUND.getHttpStatus(), serviceException.getStatusCode());


### PR DESCRIPTION
### 작업 내용 요약 
- 유저 탈퇴 시 유저 삭제하지 않고 disable 처리
  - 탈퇴한 유저 Email로 로그인 시도 시 400 에러 반환
- 유저 탈퇴 시 해당 유저를 FK 값으로 가지는 다른 데이터 삭제하지 않도록 처리
  - 이런 경우 Batch로 무효한 데이터는 일괄 삭제하도록 구현하는 것이 맞는 방향으로 판단

### 변경점
#### Member Table Column 추가
- is_enabled 컬럼 추가
- 기본값 1(true)

#### 회원가입 시 is_enabled 컬럼 true로 저장
```java
Member member = Member.builder()
			.nickname(joinReqDto.getNickname())
			.email(joinReqDto.getEmail())
			.password(passwordEncoder.encode(joinReqDto.getPassword()))
			.role(RoleType.GUEST)
			.provider(ProviderType.EMAIL)
			.isEnabled(true)
			.build();
```
#### 탈퇴한 유저 정보로 인가 처리 요청 시 400 Error 반환
```java
@Override
	public UserDetails loadUserByUsername(String userEmail) throws UsernameNotFoundException {
		log.debug("[+] loadUserByUsername start");
		Member member = memberRepository.findUserByEmail(userEmail)
				.orElseThrow(() -> new ServiceException(ServiceError.USER_NOT_FOUND));

		// 탈퇴한 회원 로그인 시도 시
		if (!member.getIsEnabled()) {
			throw new ServiceException(ServiceError.USER_ALREADY_LEAVE);
		}

		log.debug(member.getEmail());
		return new PrincipalDetails(member);
	}
```

#### PrincipalDetails 변경
```java
@Override
public boolean isEnabled() {
	return this.member.getIsEnabled();
}
```
PrincipalDetails의 isEnabled 메서드에서 member 테이블의 is_enabled 컬럼 값을 반환하도록 수정
이후 AOP로 PrincipalDetail를 파라미터로 받는 컨트롤러에서 PrincipalDetail.isEnabled() == false인 경우 컨트롤러 진입 전에 400 에러 반환하도록 리팩토링하면 좋을 것 같습니다.

#### 회원 정보 조회 시 validation 추가
```java
/**
	 * 탈퇴 유저 검증
	 *
	 * @param member 검증할 유저
	 */
	private void validateMember(Member member) {

		// 탈퇴한 멤버 조회 시
		if (!member.getIsEnabled()) {
			throw new ServiceException(ServiceError.USER_ALREADY_LEAVE);
		}
	}
```

### 비고
<!---- 리뷰어에게 하고 싶은 말이나, 참고해야할 부분이 있다면 알려주세요. -->


### 테스트
<!---- 어떤 테스트를 진행했는지 적어주세요.-->

- [ ] 테스트 코드 작성
- [ ] API 테스트 
