### PR TITLE
유통기한 null일 때 예외 처리 #215

### DIFF
--- a/src/main/java/team/rescue/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/team/rescue/auth/filter/JwtAuthenticationFilter.java
@@ -146,7 +146,8 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 		LocalDate today = LocalDate.now();
 
 		for (FridgeIngredient fridgeIngredient : fridgeIngredients) {
-			if (today.plusDays(1).isEqual(fridgeIngredient.getExpiredAt())) {
+			if (fridgeIngredient.getExpiredAt() != null && today.plusDays(1)
+					.isEqual(fridgeIngredient.getExpiredAt())) {
 				NotificationEvent event = NotificationEvent.builder()
 						.email(principalDetails.getMember().getEmail())
 						.notificationType(NotificationType.INGREDIENT_EXPIRED)


### PR DESCRIPTION
### 작업 내용 요약 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 변경점
<!---- 실제로 변경된 부분을 작성해주세요. -->
**AS-IS**
유통기한이 null인 재료일 때 `today.plusDays(1).isEqual(fridgeIngredient.getExpiredAt())`에서 NPE 발생

**TO-BE**
expiredAt이 null인 경우 다음 반복을 진행하도록 수정

### 비고
<!---- 리뷰어에게 하고 싶은 말이나, 참고해야할 부분이 있다면 알려주세요. -->


### 테스트
<!---- 어떤 테스트를 진행했는지 적어주세요.-->

- [ ] 테스트 코드 작성
- [ ] API 테스트 
